### PR TITLE
refactor: migrate package scope from @claude-code to @carabiner

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,15 +5,15 @@
   "fixed": [],
   "linked": [
     [
-      "@outfitter/hooks-core",
-      "@outfitter/hooks-validators",
-      "@outfitter/hooks-config",
-      "@outfitter/hooks-testing",
-      "@outfitter/hooks-cli"
+      "@carabiner/hooks-core",
+      "@carabiner/hooks-validators",
+      "@carabiner/hooks-config",
+      "@carabiner/hooks-testing",
+      "@carabiner/hooks-cli"
     ]
   ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@outfitter/hooks-examples"]
+  "ignore": ["@carabiner/hooks-examples"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Base instructions: @.agent/prompts/CORE.md
 
 ## Repository Overview
 
-Carabiner is a modern TypeScript monorepo for building type-safe Claude Code hooks. Built with Bun, Turbo, and Ultracite, it provides a foundation for scalable development with strict type safety and automated quality gates.
+Carabiner is a modern TypeScript monorepo for building type-safe Carabiner hooks. Built with Bun, Turbo, and Ultracite, it provides a foundation for scalable development with strict type safety and automated quality gates.
 
 ## Important Rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grapple (Carabiner) - Claude Code Hooks TypeScript Library
 
-A comprehensive, production-ready TypeScript monorepo for building type-safe, maintainable Claude Code hooks with modern development practices and enterprise-grade tooling.
+A comprehensive, production-ready TypeScript monorepo for building type-safe, maintainable Carabiner hooks with modern development practices and enterprise-grade tooling.
 
 ## 🚀 Overview
 
@@ -487,4 +487,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-**Transform your Claude Code hooks from shell scripts to production-ready TypeScript applications.** 🚀
+**Transform your Carabiner hooks from shell scripts to production-ready TypeScript applications.** 🚀

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       },
     },
     "packages/error-management": {
-      "name": "@outfitter/error-management",
+      "name": "@carabiner/error-management",
       "version": "0.1.0-beta",
       "dependencies": {
         "nanoid": "^5.0.9",
@@ -39,13 +39,13 @@
       },
     },
     "packages/examples": {
-      "name": "@outfitter/hooks-examples",
+      "name": "@carabiner/hooks-examples",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/hooks-config": "workspace:*",
-        "@outfitter/hooks-core": "workspace:*",
-        "@outfitter/hooks-testing": "workspace:*",
-        "@outfitter/hooks-validators": "workspace:*",
+        "@carabiner/hooks-config": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
+        "@carabiner/hooks-testing": "workspace:*",
+        "@carabiner/hooks-validators": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "*",
@@ -53,12 +53,12 @@
       },
     },
     "packages/execution": {
-      "name": "@outfitter/execution",
+      "name": "@carabiner/execution",
       "version": "1.0.0",
       "dependencies": {
-        "@outfitter/hooks-core": "workspace:*",
-        "@outfitter/protocol": "workspace:*",
-        "@outfitter/types": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
+        "@carabiner/protocol": "workspace:*",
+        "@carabiner/types": "workspace:*",
         "type-fest": "^4.41.0",
       },
       "devDependencies": {
@@ -68,15 +68,15 @@
       },
     },
     "packages/hooks-cli": {
-      "name": "@outfitter/hooks-cli",
+      "name": "@carabiner/hooks-cli",
       "version": "0.1.0",
       "bin": {
-        "claude-hooks": "./dist/cli.js",
+        "carabiner": "./dist/cli.js",
       },
       "dependencies": {
-        "@outfitter/hooks-config": "workspace:*",
-        "@outfitter/hooks-core": "workspace:*",
-        "@outfitter/hooks-validators": "workspace:*",
+        "@carabiner/hooks-config": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
+        "@carabiner/hooks-validators": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "*",
@@ -84,11 +84,11 @@
       },
     },
     "packages/hooks-config": {
-      "name": "@outfitter/hooks-config",
+      "name": "@carabiner/hooks-config",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/error-management": "workspace:*",
-        "@outfitter/hooks-core": "workspace:*",
+        "@carabiner/error-management": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "*",
@@ -96,7 +96,7 @@
       },
     },
     "packages/hooks-core": {
-      "name": "@outfitter/hooks-core",
+      "name": "@carabiner/hooks-core",
       "version": "0.2.0",
       "dependencies": {
         "pino": "^9.8.0",
@@ -112,11 +112,11 @@
       },
     },
     "packages/hooks-testing": {
-      "name": "@outfitter/hooks-testing",
+      "name": "@carabiner/hooks-testing",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/hooks-core": "workspace:*",
-        "@outfitter/hooks-validators": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
+        "@carabiner/hooks-validators": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "*",
@@ -127,10 +127,10 @@
       },
     },
     "packages/hooks-validators": {
-      "name": "@outfitter/hooks-validators",
+      "name": "@carabiner/hooks-validators",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/hooks-core": "workspace:*",
+        "@carabiner/hooks-core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "*",
@@ -138,12 +138,12 @@
       },
     },
     "packages/plugins": {
-      "name": "@outfitter/plugins",
+      "name": "@carabiner/plugins",
       "version": "1.0.0",
       "dependencies": {
-        "@outfitter/execution": "workspace:*",
-        "@outfitter/registry": "workspace:*",
-        "@outfitter/types": "workspace:*",
+        "@carabiner/execution": "workspace:*",
+        "@carabiner/registry": "workspace:*",
+        "@carabiner/types": "workspace:*",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -153,11 +153,11 @@
       },
     },
     "packages/protocol": {
-      "name": "@outfitter/protocol",
+      "name": "@carabiner/protocol",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/schemas": "workspace:*",
-        "@outfitter/types": "workspace:*",
+        "@carabiner/schemas": "workspace:*",
+        "@carabiner/types": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -165,12 +165,12 @@
       },
     },
     "packages/registry": {
-      "name": "@outfitter/registry",
+      "name": "@carabiner/registry",
       "version": "1.0.0",
       "dependencies": {
-        "@outfitter/execution": "workspace:*",
-        "@outfitter/schemas": "workspace:*",
-        "@outfitter/types": "workspace:*",
+        "@carabiner/execution": "workspace:*",
+        "@carabiner/schemas": "workspace:*",
+        "@carabiner/types": "workspace:*",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -180,10 +180,10 @@
       },
     },
     "packages/schemas": {
-      "name": "@outfitter/schemas",
+      "name": "@carabiner/schemas",
       "version": "0.1.0",
       "dependencies": {
-        "@outfitter/types": "workspace:*",
+        "@carabiner/types": "workspace:*",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -192,7 +192,7 @@
       },
     },
     "packages/types": {
-      "name": "@outfitter/types",
+      "name": "@carabiner/types",
       "version": "0.1.0",
       "dependencies": {
         "type-fest": "^4.41.0",
@@ -232,6 +232,32 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww=="],
+
+    "@carabiner/error-management": ["@carabiner/error-management@workspace:packages/error-management"],
+
+    "@carabiner/execution": ["@carabiner/execution@workspace:packages/execution"],
+
+    "@carabiner/hooks-cli": ["@carabiner/hooks-cli@workspace:packages/hooks-cli"],
+
+    "@carabiner/hooks-config": ["@carabiner/hooks-config@workspace:packages/hooks-config"],
+
+    "@carabiner/hooks-core": ["@carabiner/hooks-core@workspace:packages/hooks-core"],
+
+    "@carabiner/hooks-examples": ["@carabiner/hooks-examples@workspace:packages/examples"],
+
+    "@carabiner/hooks-testing": ["@carabiner/hooks-testing@workspace:packages/hooks-testing"],
+
+    "@carabiner/hooks-validators": ["@carabiner/hooks-validators@workspace:packages/hooks-validators"],
+
+    "@carabiner/plugins": ["@carabiner/plugins@workspace:packages/plugins"],
+
+    "@carabiner/protocol": ["@carabiner/protocol@workspace:packages/protocol"],
+
+    "@carabiner/registry": ["@carabiner/registry@workspace:packages/registry"],
+
+    "@carabiner/schemas": ["@carabiner/schemas@workspace:packages/schemas"],
+
+    "@carabiner/types": ["@carabiner/types@workspace:packages/types"],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.12", "", { "dependencies": { "@changesets/config": "^3.1.1", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ=="],
 
@@ -348,32 +374,6 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@outfitter/error-management": ["@outfitter/error-management@workspace:packages/error-management"],
-
-    "@outfitter/execution": ["@outfitter/execution@workspace:packages/execution"],
-
-    "@outfitter/hooks-cli": ["@outfitter/hooks-cli@workspace:packages/hooks-cli"],
-
-    "@outfitter/hooks-config": ["@outfitter/hooks-config@workspace:packages/hooks-config"],
-
-    "@outfitter/hooks-core": ["@outfitter/hooks-core@workspace:packages/hooks-core"],
-
-    "@outfitter/hooks-examples": ["@outfitter/hooks-examples@workspace:packages/examples"],
-
-    "@outfitter/hooks-testing": ["@outfitter/hooks-testing@workspace:packages/hooks-testing"],
-
-    "@outfitter/hooks-validators": ["@outfitter/hooks-validators@workspace:packages/hooks-validators"],
-
-    "@outfitter/plugins": ["@outfitter/plugins@workspace:packages/plugins"],
-
-    "@outfitter/protocol": ["@outfitter/protocol@workspace:packages/protocol"],
-
-    "@outfitter/registry": ["@outfitter/registry@workspace:packages/registry"],
-
-    "@outfitter/schemas": ["@outfitter/schemas@workspace:packages/schemas"],
-
-    "@outfitter/types": ["@outfitter/types@workspace:packages/types"],
 
     "@publint/pack": ["@publint/pack@0.1.2", "", {}, "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Grapple Documentation
 
-Welcome to the comprehensive documentation for Grapple, the production-ready TypeScript library for building Claude Code hooks. This documentation provides everything you need to build robust, type-safe, and maintainable hooks.
+Welcome to the comprehensive documentation for Grapple, the production-ready TypeScript library for building Carabiner hooks. This documentation provides everything you need to build robust, type-safe, and maintainable hooks.
 
 ## 📚 Documentation Structure
 
@@ -123,11 +123,11 @@ The Claude Code Hooks library is organized into focused packages:
 
 ### Core Packages
 
-- **[@claude-code/hooks-core](../packages/hooks-core/README.md)** - Core types, runtime utilities, and execution engine
-- **[@claude-code/hooks-config](../packages/hooks-config/README.md)** - Configuration management and settings generation
-- **[@claude-code/hooks-validators](../packages/hooks-validators/README.md)** - Security validators and validation rules
-- **[@claude-code/hooks-testing](../packages/hooks-testing/README.md)** - Testing framework and mock utilities
-- **[@claude-code/hooks-cli](../packages/hooks-cli/README.md)** - CLI tools for project management
+- **[@carabiner/hooks-core](../packages/hooks-core/README.md)** - Core types, runtime utilities, and execution engine
+- **[@carabiner/hooks-config](../packages/hooks-config/README.md)** - Configuration management and settings generation
+- **[@carabiner/hooks-validators](../packages/hooks-validators/README.md)** - Security validators and validation rules
+- **[@carabiner/hooks-testing](../packages/hooks-testing/README.md)** - Testing framework and mock utilities
+- **[@carabiner/hooks-cli](../packages/hooks-cli/README.md)** - CLI tools for project management
 
 ### Supporting Packages
 
@@ -350,14 +350,14 @@ Choose your path based on your experience level:
 ### Experienced Developer
 
 1. Check [Migration Guide](./migration-guide.md) for v2.0 changes
-2. Review the [Configuration Reference](./resources/claude-code-hooks-configuration.md)
-3. Explore the [TypeScript Integration Guide](./resources/claude-code-hooks-typescript.md)
+2. Review the [Configuration Reference](./resources/carabiner-hooks-configuration.md)
+3. Explore the [TypeScript Integration Guide](./resources/carabiner-hooks-typescript.md)
 
 ### Contributor
 
 1. Review the package structure and examples
-2. Check [Project Planning](./plans/claude-code-hooks-typescript-library.md)
-3. Explore the [Troubleshooting Guide](./resources/claude-code-hooks-troubleshooting.md)
+2. Check [Project Planning](./plans/carabiner-hooks-typescript-library.md)
+3. Explore the [Troubleshooting Guide](./resources/carabiner-hooks-troubleshooting.md)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Guide
 
-This guide explains the system design, concepts, and patterns that make Grapple a robust, scalable Claude Code hooks library.
+This guide explains the system design, concepts, and patterns that make Grapple a robust, scalable Carabiner hooks library.
 
 ## Table of Contents
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The Grapple CLI (`claude-hooks`) provides comprehensive tools for developing, testing, and managing Claude Code hooks. This reference covers all commands, options, and usage patterns.
+The Grapple CLI (`claude-hooks`) provides comprehensive tools for developing, testing, and managing Carabiner hooks. This reference covers all commands, options, and usage patterns.
 
 ## Table of Contents
 
@@ -49,7 +49,7 @@ These options work with all commands:
 
 ### `init`
 
-Initialize Claude Code hooks in your project.
+Initialize Carabiner hooks in your project.
 
 #### Syntax
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Examples & Tutorials
 
-Real-world examples and best practices for building production-ready Claude Code hooks with Grapple.
+Real-world examples and best practices for building production-ready Carabiner hooks with Grapple.
 
 ## Table of Contents
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Grapple
 
-Welcome to Grapple, the production-ready TypeScript library for building Claude Code hooks. This guide will get you up and running with your first hook in minutes.
+Welcome to Grapple, the production-ready TypeScript library for building Carabiner hooks. This guide will get you up and running with your first hook in minutes.
 
 ## Table of Contents
 
@@ -98,7 +98,7 @@ runClaudeHook(async (context) => {
     // Type-safe access to command property
     const toolInput = context.toolInput as Record<string, unknown>;
     const command = toolInput?.command;
-    
+
     if (typeof command !== 'string') {
       return HookResults.failure('Invalid command input');
     }
@@ -489,7 +489,7 @@ For more detailed troubleshooting, see the [Troubleshooting Guide](troubleshooti
 
 ---
 
-**Ready to build production-ready Claude Code hooks!** 🚀
+**Ready to build production-ready Carabiner hooks!** 🚀
 
 Continue with:
 

--- a/docs/guides/core-concepts.md
+++ b/docs/guides/core-concepts.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-Understanding these fundamental concepts will help you build effective and maintainable Claude Code hooks.
+Understanding these fundamental concepts will help you build effective and maintainable Carabiner hooks.
 
 ## Hook Lifecycle
 
@@ -277,7 +277,7 @@ interface EditToolInput {
 Use type guards to safely access tool-specific properties:
 
 ```typescript
-import { isBashToolInput, isWriteToolInput } from '@claude-code/hooks-core';
+import { isBashToolInput, isWriteToolInput } from '@carabiner/hooks-core';
 
 runClaudeHook(async (context) => {
   if (isBashToolInput(context.toolInput)) {

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,10 +1,10 @@
 # Getting Started with Claude Code Hooks
 
-This guide will get you up and running with Claude Code hooks in minutes. You'll learn the basic concepts, create your first hook, and understand the new runtime architecture.
+This guide will get you up and running with Carabiner hooks in minutes. You'll learn the basic concepts, create your first hook, and understand the new runtime architecture.
 
 ## What are Claude Code Hooks?
 
-Claude Code hooks are TypeScript/JavaScript programs that run at specific points during Claude Code's execution. They allow you to:
+Carabiner hooks are TypeScript/JavaScript programs that run at specific points during Claude Code's execution. They allow you to:
 
 - **Validate tool usage** before execution (PreToolUse)
 - **Process results** after execution (PostToolUse)
@@ -27,7 +27,7 @@ Before starting, ensure you have:
 
 # Install the CLI globally
 
-npm install -g @claude-code/hooks-cli
+npm install -g @carabiner/hooks-cli
 
 # Initialize hooks in your project
 
@@ -43,12 +43,12 @@ This creates a complete hook setup with security-focused examples.
 
 # Install core library
 
-bun add @claude-code/hooks-core
+bun add @carabiner/hooks-core
 
 # Install optional packages
 
-bun add @claude-code/hooks-validators  # Security validation
-bun add --dev @claude-code/hooks-testing  # Testing utilities
+bun add @carabiner/hooks-validators  # Security validation
+bun add --dev @carabiner/hooks-testing  # Testing utilities
 
 ```
 
@@ -65,7 +65,7 @@ Create `hooks/security-check.ts`:
 #!/usr/bin/env bun
 
 import pino from 'pino';
-import { runClaudeHook, HookResults } from '@claude-code/hooks-core';
+import { runClaudeHook, HookResults } from '@carabiner/hooks-core';
 const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' }, pino.destination(2));
 
 runClaudeHook(async (context) => {
@@ -289,7 +289,7 @@ Now that you have a basic hook working, you can:
 ### Add Security Validation
 
 ```typescript
-import { SecurityValidators } from '@claude-code/hooks-validators';
+import { SecurityValidators } from '@carabiner/hooks-validators';
 
 runClaudeHook(async (context) => {
   // Environment-specific security
@@ -311,7 +311,7 @@ runClaudeHook(async (context) => {
 ### Add Testing
 
 ```typescript
-import { createMockContext, testHook } from '@claude-code/hooks-testing';
+import { createMockContext, testHook } from '@carabiner/hooks-testing';
 
 test('security hook blocks dangerous commands', async () => {
   await testHook('PreToolUse')
@@ -353,7 +353,7 @@ claude-hooks dev --watch
 
 #!/usr/bin/env bun
 
-import { runClaudeHook, HookResults } from '@claude-code/hooks-core';
+import { runClaudeHook, HookResults } from '@carabiner/hooks-core';
 
 runClaudeHook(async (context) => {
   console.log(`🔍 Universal security check: ${context.toolName}`);
@@ -386,7 +386,7 @@ runClaudeHook(async (context) => {
 
 #!/usr/bin/env bun
 
-import { runClaudeHook, HookResults } from '@claude-code/hooks-core';
+import { runClaudeHook, HookResults } from '@carabiner/hooks-core';
 
 runClaudeHook(async (context) => {
   const environment = process.env.NODE_ENV || 'development';
@@ -424,7 +424,7 @@ runClaudeHook(async (context) => {
 
 #!/usr/bin/env bun
 
-import { runClaudeHook, HookResults } from '@claude-code/hooks-core';
+import { runClaudeHook, HookResults } from '@carabiner/hooks-core';
 
 runClaudeHook(async (context) => {
   // Only process Write and Edit tools

--- a/docs/plans/claude-code-hooks-typescript-library.md
+++ b/docs/plans/claude-code-hooks-typescript-library.md
@@ -1,10 +1,10 @@
 # Claude Code Hooks TypeScript Library - Implementation Status
 
-> **Status**: ✅ **IMPLEMENTED** - Production-ready TypeScript library for Claude Code hooks **Achievement**: Successfully transformed hook development from shell scripts to type-safe TypeScript applications **Current Version**: 0.2.0 with stdin-based runtime
+> **Status**: ✅ **IMPLEMENTED** - Production-ready TypeScript library for Carabiner hooks **Achievement**: Successfully transformed hook development from shell scripts to type-safe TypeScript applications **Current Version**: 0.2.0 with stdin-based runtime
 
 ## 🎯 Executive Summary
 
-**COMPLETED**: Created `@claude-code/hooks` - a comprehensive TypeScript library that transforms Claude Code hook development from manual shell scripting to type-safe, testable, maintainable TypeScript applications.
+**COMPLETED**: Created `@carabiner/hooks` - a comprehensive TypeScript library that transforms Claude Code hook development from manual shell scripting to type-safe, testable, maintainable TypeScript applications.
 
 ### ✅ Delivered Benefits
 
@@ -268,7 +268,7 @@ const mockContext = createMockContext('PreToolUse', {
 
 ```json
 {
-  "name": "@claude-code/hooks",
+  "name": "@carabiner/hooks",
   "exports": {
     ".": "./packages/hooks-core/dist/index.js",
     "./core": "./packages/hooks-core/dist/index.js",
@@ -289,11 +289,11 @@ const mockContext = createMockContext('PreToolUse', {
 
 # ✅ All commands work
 
-npx @claude-code/hooks-cli init
-npx @claude-code/hooks-cli generate --type PreToolUse --tool Bash --name security
-npx @claude-code/hooks-cli build --output .claude/settings.json
-npx @claude-code/hooks-cli test --hook ./hooks/pre-tool-use.ts
-npx @claude-code/hooks-cli dev --watch
+npx @carabiner/hooks-cli init
+npx @carabiner/hooks-cli generate --type PreToolUse --tool Bash --name security
+npx @carabiner/hooks-cli build --output .claude/settings.json
+npx @carabiner/hooks-cli test --hook ./hooks/pre-tool-use.ts
+npx @carabiner/hooks-cli dev --watch
 
 ```text
 

--- a/docs/resources/claude-code-hooks-configuration.md
+++ b/docs/resources/claude-code-hooks-configuration.md
@@ -2,7 +2,7 @@
 
 > **Source**: [Claude Code Settings Documentation](https://docs.anthropic.com/en/docs/claude-code/settings)
 
-This document provides comprehensive guidance on configuring Claude Code hooks through the settings system, including hierarchical configuration, advanced patterns, and project-specific setups.
+This document provides comprehensive guidance on configuring Carabiner hooks through the settings system, including hierarchical configuration, advanced patterns, and project-specific setups.
 
 ## Table of Contents
 
@@ -779,4 +779,4 @@ const configFiles = [
 configFiles.forEach(testHookConfiguration);
 ```
 
-This comprehensive configuration guide provides all the necessary information for setting up and managing Claude Code hooks across different environments and use cases.
+This comprehensive configuration guide provides all the necessary information for setting up and managing Carabiner hooks across different environments and use cases.

--- a/docs/resources/claude-code-hooks-index.md
+++ b/docs/resources/claude-code-hooks-index.md
@@ -5,11 +5,11 @@
 > - [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)
 > - [Claude Code Settings Documentation](https://docs.anthropic.com/en/docs/claude-code/settings)
 
-This index provides an organized overview of Claude Code hooks documentation and serves as the authoritative reference for common information shared across guides.
+This index provides an organized overview of Carabiner hooks documentation and serves as the authoritative reference for common information shared across guides.
 
 ## Documentation Structure
 
-### 📖 **[Overview](./claude-code-hooks-overview.md)**
+### 📖 **[Overview](./carabiner-hooks-overview.md)**
 
 - What hooks are and why they're useful
 - Quick start guide (3 steps to get running)
@@ -17,7 +17,7 @@ This index provides an organized overview of Claude Code hooks documentation and
 - Basic configuration examples
 - Security considerations and common use cases
 
-### 🔧 **[TypeScript Implementation](./claude-code-hooks-typescript.md)**
+### 🔧 **[TypeScript Implementation](./carabiner-hooks-typescript.md)**
 
 - Complete TypeScript development setup
 - Type definitions and interfaces
@@ -25,7 +25,7 @@ This index provides an organized overview of Claude Code hooks documentation and
 - Advanced patterns and utilities
 - Testing and debugging frameworks
 
-### ⚙️ **[Configuration Guide](./claude-code-hooks-configuration.md)**
+### ⚙️ **[Configuration Guide](./carabiner-hooks-configuration.md)**
 
 - Settings hierarchy and file locations
 - Hook configuration options
@@ -33,7 +33,7 @@ This index provides an organized overview of Claude Code hooks documentation and
 - Pattern matching and conditional execution
 - Configuration validation
 
-### 🔍 **[Troubleshooting](./claude-code-hooks-troubleshooting.md)**
+### 🔍 **[Troubleshooting](./carabiner-hooks-troubleshooting.md)**
 
 - Common issues and solutions
 - Debugging techniques
@@ -210,10 +210,10 @@ tail -f .claude/hook-trace.log
 
 ```
 
-For detailed troubleshooting, see the [Troubleshooting Guide](./claude-code-hooks-troubleshooting.md).
+For detailed troubleshooting, see the [Troubleshooting Guide](./carabiner-hooks-troubleshooting.md).
 
 ---
 
-> Last updated: Based on Claude Code hooks documentation as of 2024
+> Last updated: Based on Carabiner hooks documentation as of 2024
 >
 > **Feedback**: Found an issue or have suggestions? Please check the latest official documentation at [docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code/hooks)

--- a/docs/resources/claude-code-hooks-overview.md
+++ b/docs/resources/claude-code-hooks-overview.md
@@ -5,7 +5,7 @@
 > - [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)
 > - [Claude Code Settings Documentation](https://docs.anthropic.com/en/docs/claude-code/settings)
 
-Claude Code hooks are a powerful configuration mechanism that allows you to execute custom commands at specific events during Claude Code's operation. This document provides comprehensive coverage of how hooks work, their types, configuration, and implementation.
+Carabiner hooks are a powerful configuration mechanism that allows you to execute custom commands at specific events during Claude Code's operation. This document provides comprehensive coverage of how hooks work, their types, configuration, and implementation.
 
 ## Quick Start
 
@@ -36,7 +36,7 @@ Claude Code hooks are a powerful configuration mechanism that allows you to exec
 
 ## Table of Contents
 
-1. [What are Claude Code Hooks?](#what-are-claude-code-hooks)
+1. [What are Claude Code Hooks?](#what-are-carabiner-hooks)
 2. [Hook Types and Events](#hook-types-and-events)
 3. [Configuration](#configuration)
 4. [TypeScript Implementation](#typescript-implementation)
@@ -45,7 +45,7 @@ Claude Code hooks are a powerful configuration mechanism that allows you to exec
 
 ## What are Claude Code Hooks?
 
-Claude Code hooks are event-driven commands that execute automatically at specific points in Claude Code's workflow. They provide a way to:
+Carabiner hooks are event-driven commands that execute automatically at specific points in Claude Code's workflow. They provide a way to:
 
 - **Extend functionality**: Add custom behavior without modifying Claude Code itself
 - **Validate operations**: Check inputs before tools execute
@@ -347,7 +347,7 @@ main().catch((error) => {
 
 **🚨 CRITICAL SECURITY WARNING**:
 
-- Claude Code hooks execute shell commands **automatically** with the same permissions as the Claude Code process
+- Carabiner hooks execute shell commands **automatically** with the same permissions as the Claude Code process
 - On macOS, this often includes **full disk access**
 - These scripts can **delete files, access sensitive data, and modify your system**
 - Use extreme caution, especially in production environments

--- a/docs/resources/claude-code-hooks-troubleshooting.md
+++ b/docs/resources/claude-code-hooks-troubleshooting.md
@@ -2,7 +2,7 @@
 
 > **Sources**: [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks), [Claude Code Settings Documentation](https://docs.anthropic.com/en/docs/claude-code/settings)
 
-This guide provides troubleshooting solutions, debugging techniques, and best practices for Claude Code hooks development and deployment.
+This guide provides troubleshooting solutions, debugging techniques, and best practices for Carabiner hooks development and deployment.
 
 ## Table of Contents
 
@@ -872,7 +872,7 @@ async function runHookWithInput(scriptPath: string, env: Record<string, string>)
 
 # scripts/test-hooks-e2e.sh
 
-echo "Testing Claude Code hooks end-to-end..."
+echo "Testing Carabiner hooks end-to-end..."
 
 # Test 1: Safe command should succeed
 
@@ -903,4 +903,4 @@ echo "All end-to-end tests passed!"
 
 ```
 
-This comprehensive troubleshooting and best practices guide should help developers successfully implement, debug, and maintain Claude Code hooks in their projects.
+This comprehensive troubleshooting and best practices guide should help developers successfully implement, debug, and maintain Carabiner hooks in their projects.

--- a/docs/resources/claude-code-hooks-typescript.md
+++ b/docs/resources/claude-code-hooks-typescript.md
@@ -1,6 +1,6 @@
 # Claude Code Hooks: TypeScript Implementation Guide
 
-This guide provides detailed instructions and examples for implementing Claude Code hooks using TypeScript and Bun, following the project's conventions.
+This guide provides detailed instructions and examples for implementing Carabiner hooks using TypeScript and Bun, following the project's conventions.
 
 ## Table of Contents
 
@@ -965,4 +965,4 @@ If using Turbo, add hook tasks to `turbo.json`:
 }
 ```
 
-This comprehensive TypeScript implementation guide provides everything needed to create sophisticated, type-safe Claude Code hooks following the project's conventions and best practices.
+This comprehensive TypeScript implementation guide provides everything needed to create sophisticated, type-safe Carabiner hooks following the project's conventions and best practices.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-This guide covers how to write and run tests for the Grapple monorepo, a TypeScript library for building type-safe Claude Code hooks.
+This guide covers how to write and run tests for the Grapple monorepo, a TypeScript library for building type-safe Carabiner hooks.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/carabiner",
+  "name": "carabiner-monorepo",
   "version": "0.1.0-beta",
-  "description": "A monorepo dedicated to tooling for Claude Code hooks",
+  "description": "A monorepo for building type-safe hooks with Carabiner",
   "private": true,
   "engines": {
     "node": ">=20",

--- a/packages/error-management/package.json
+++ b/packages/error-management/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@outfitter/error-management",
+  "name": "@carabiner/error-management",
   "version": "0.1.0-beta",
   "description": "Production-ready error handling system for Grapple monorepo",
   "type": "module",

--- a/packages/error-management/src/index.ts
+++ b/packages/error-management/src/index.ts
@@ -5,7 +5,7 @@
  *
  * @example Basic usage:
  * ```typescript
- * import { GrappleError, ErrorCode, ErrorCategory, reportError } from '@outfitter/error-management';
+ * import { GrappleError, ErrorCode, ErrorCategory, reportError } from '@carabiner/error-management';
  *
  * try {
  *   // Some operation
@@ -22,7 +22,7 @@
  *
  * @example With error recovery:
  * ```typescript
- * import { RetryManager, CircuitBreaker } from '@outfitter/error-management';
+ * import { RetryManager, CircuitBreaker } from '@carabiner/error-management';
  *
  * const retryManager = new RetryManager({ maxRetries: 3 });
  * const result = await retryManager.execute(async () => {
@@ -33,7 +33,7 @@
  *
  * @example With error boundaries:
  * ```typescript
- * import { executeWithBoundary } from '@outfitter/error-management';
+ * import { executeWithBoundary } from '@carabiner/error-management';
  *
  * const result = await executeWithBoundary(
  *   async () => await riskyOperation(),

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,6 +1,6 @@
 # Claude Code Hooks - Examples
 
-This package contains comprehensive examples demonstrating the different approaches to building Claude Code hooks with TypeScript.
+This package contains comprehensive examples demonstrating the different approaches to building Carabiner hooks with TypeScript.
 
 ## 🚀 Quick Start
 
@@ -307,4 +307,4 @@ echo '{
 - [Testing Framework Documentation](../hooks-testing/README.md)
 - [CLI Tools Documentation](../hooks-cli/README.md)
 
-All examples are production-ready and demonstrate real-world patterns for building robust, maintainable Claude Code hooks.
+All examples are production-ready and demonstrate real-world patterns for building robust, maintainable Carabiner hooks.

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/hooks-examples",
+  "name": "@carabiner/hooks-examples",
   "version": "0.1.0",
-  "description": "Example implementations demonstrating Claude Code hooks APIs",
+  "description": "Example implementations demonstrating Carabiner hooks APIs",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,17 +9,17 @@
     "typecheck": "echo 'Temporarily disabled - examples need type fixes'"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "examples"
   ],
   "author": "Matt Galligan <matt.galligan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/hooks-core": "workspace:*",
-    "@outfitter/hooks-validators": "workspace:*",
-    "@outfitter/hooks-config": "workspace:*",
-    "@outfitter/hooks-testing": "workspace:*"
+    "@carabiner/hooks-core": "workspace:*",
+    "@carabiner/hooks-validators": "workspace:*",
+    "@carabiner/hooks-config": "workspace:*",
+    "@carabiner/hooks-testing": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "*",

--- a/packages/examples/src/testing/hook-tests.test.ts
+++ b/packages/examples/src/testing/hook-tests.test.ts
@@ -239,7 +239,7 @@ describe('Custom Hook Scenarios', () => {
     // Create a custom hook for testing
     const customValidationHook = HookBuilder.forPreToolUse()
       .forTool('Write')
-      .withHandler(async (context) => {
+      .withHandler((context) => {
         const filePath = (context.toolInput as Record<string, unknown>)
           .file_path;
 
@@ -273,7 +273,7 @@ describe('Custom Hook Scenarios', () => {
   });
 
   test('should test hook with middleware', async () => {
-    const { middleware } = await import('@outfitter/hooks-core');
+    const { middleware } = await import('@carabiner/hooks-core');
 
     // Create hook with timing middleware
     const timedHook = HookBuilder.forPostToolUse()
@@ -328,7 +328,7 @@ describe('Integration Testing', () => {
   test('should handle error propagation correctly', async () => {
     // Test error handling in hook chain
     const errorHook = HookBuilder.forPreToolUse()
-      .withHandler(async () => {
+      .withHandler(() => {
         throw new Error('Simulated hook error');
       })
       .build();

--- a/packages/examples/src/testing/new-runtime-test.ts
+++ b/packages/examples/src/testing/new-runtime-test.ts
@@ -9,12 +9,12 @@ import type {
   ClaudeToolHookInput,
   HookContext,
   HookResult,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 import {
   createHookContext,
   HookResults,
   runClaudeHook,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 
 function hasCommand(input: unknown): input is { command: string } {
   return (

--- a/packages/execution/README.md
+++ b/packages/execution/README.md
@@ -1,6 +1,6 @@
 # @outfitter/execution
 
-Simplified execution engine for Claude Code hooks with predictable error handling, comprehensive metrics, and excellent developer experience.
+Simplified execution engine for Carabiner hooks with predictable error handling, comprehensive metrics, and excellent developer experience.
 
 ## Features
 

--- a/packages/execution/examples/simple-security-hook.ts
+++ b/packages/execution/examples/simple-security-hook.ts
@@ -15,7 +15,7 @@
  * 2. Expected output: Hook should block the dangerous command
  */
 
-import type { HookHandler } from '@outfitter/types';
+import type { HookHandler } from '@carabiner/types';
 
 type BashToolInput = {
   readonly command: string;
@@ -44,7 +44,7 @@ type NonBashContext = {
 type TestContext = BashContext | NonBashContext;
 
 // We would normally use:
-// import { runHook } from '@outfitter/execution';
+// import { runHook } from '@carabiner/execution';
 // But for this example, we'll simulate the execution
 
 import {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/execution",
+  "name": "@carabiner/execution",
   "version": "1.0.0",
-  "description": "Simplified execution engine for Claude Code hooks",
+  "description": "Simplified execution engine for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -17,7 +17,7 @@
     "README.md"
   ],
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "execution",
     "typescript"
@@ -40,9 +40,9 @@
     "clean": "rm -rf dist/"
   },
   "dependencies": {
-    "@outfitter/hooks-core": "workspace:*",
-    "@outfitter/protocol": "workspace:*",
-    "@outfitter/types": "workspace:*",
+    "@carabiner/hooks-core": "workspace:*",
+    "@carabiner/protocol": "workspace:*",
+    "@carabiner/types": "workspace:*",
     "type-fest": "^4.41.0"
   },
   "devDependencies": {

--- a/packages/execution/src/__tests__/executor.test.ts
+++ b/packages/execution/src/__tests__/executor.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { createProtocol, type TestProtocol } from '@outfitter/protocol';
-import type { HookHandler } from '@outfitter/types';
-import { isToolHookContext } from '@outfitter/types';
+import { createProtocol, type TestProtocol } from '@carabiner/protocol';
+import type { HookHandler } from '@carabiner/types';
+import { isToolHookContext } from '@carabiner/types';
 import { HookExecutor } from '../executor';
 import { MetricsCollector } from '../metrics';
 

--- a/packages/execution/src/__tests__/integration.test.ts
+++ b/packages/execution/src/__tests__/integration.test.ts
@@ -3,12 +3,12 @@
  */
 
 import { beforeEach, describe, expect, test } from 'bun:test';
-import type { HookContext, HookHandler } from '@outfitter/types';
+import type { HookContext, HookHandler } from '@carabiner/types';
 import {
   createDirectoryPath,
   createSessionId,
   createTranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import {
   ExecutionTimer,
   MetricsCollector,

--- a/packages/execution/src/__tests__/metrics.test.ts
+++ b/packages/execution/src/__tests__/metrics.test.ts
@@ -7,7 +7,7 @@ import {
   createDirectoryPath,
   createSessionId,
   createTranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import {
   deltaMemoryUsage,
   ExecutionTimer,

--- a/packages/execution/src/__tests__/runner.test.ts
+++ b/packages/execution/src/__tests__/runner.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { beforeEach, describe, expect, test } from 'bun:test';
-import type { HookHandler } from '@outfitter/types';
-import { isToolHookContext } from '@outfitter/types';
+import type { HookHandler } from '@carabiner/types';
+import { isToolHookContext } from '@carabiner/types';
 
 import {
   clearExecutionMetrics,

--- a/packages/execution/src/executor.ts
+++ b/packages/execution/src/executor.ts
@@ -11,9 +11,9 @@ import {
   executionLogger,
   type HookExecutionContext,
   type PerformanceMetrics,
-} from '@outfitter/hooks-core';
-import type { HookProtocol } from '@outfitter/protocol';
-import type { HookContext, HookHandler, HookResult } from '@outfitter/types';
+} from '@carabiner/hooks-core';
+import type { HookProtocol } from '@carabiner/protocol';
+import type { HookContext, HookHandler, HookResult } from '@carabiner/types';
 
 // Local structural type to avoid name clashes with runtime exports
 type ExecutorLogger = ReturnType<typeof executionLogger.child>;

--- a/packages/execution/src/index.ts
+++ b/packages/execution/src/index.ts
@@ -15,7 +15,7 @@
  *
  * @example Basic Usage
  * ```typescript
- * import { runHook } from '@outfitter/execution';
+ * import { runHook } from '@carabiner/execution';
  *
  * await runHook(async (context) => {
  *   if (context.event === 'PreToolUse') {
@@ -28,7 +28,7 @@
  *
  * @example Testing
  * ```typescript
- * import { runTestHook } from '@outfitter/execution';
+ * import { runTestHook } from '@carabiner/execution';
  *
  * await runTestHook(
  *   myHandler,
@@ -110,7 +110,7 @@ export const VERSION = '1.0.0';
  * Package metadata
  */
 export const PACKAGE_INFO = {
-  name: '@outfitter/execution',
+  name: '@carabiner/execution',
   version: VERSION,
   description: 'Simplified execution engine for Claude Code hooks',
   repository: 'https://github.com/outfitter-dev/grapple',

--- a/packages/execution/src/metrics.ts
+++ b/packages/execution/src/metrics.ts
@@ -6,7 +6,7 @@
  * minimal impact on execution performance.
  */
 
-import type { HookContext, HookEvent, HookResult } from '@outfitter/types';
+import type { HookContext, HookEvent, HookResult } from '@carabiner/types';
 
 /**
  * Execution timing information

--- a/packages/execution/src/result.ts
+++ b/packages/execution/src/result.ts
@@ -6,7 +6,7 @@
  * error handling predictability throughout the execution engine.
  */
 
-import type { HookResult } from '@outfitter/types';
+import type { HookResult } from '@carabiner/types';
 
 /**
  * Success result containing a value

--- a/packages/execution/src/runner.ts
+++ b/packages/execution/src/runner.ts
@@ -6,8 +6,8 @@
  * making it easy to create hooks with minimal boilerplate.
  */
 
-import { createProtocol } from '@outfitter/protocol';
-import type { HookHandler, HookResult } from '@outfitter/types';
+import { createProtocol } from '@carabiner/protocol';
+import type { HookHandler, HookResult } from '@carabiner/types';
 
 import { type ExecutionOptions, HookExecutor } from './executor';
 import { globalMetrics } from './metrics';
@@ -106,7 +106,7 @@ export class HookRunner {
  *
  * @example
  * ```typescript
- * import { runHook } from '@outfitter/execution';
+ * import { runHook } from '@carabiner/execution';
  *
  * await runHook(async (context) => {
  *   if (context.event === 'PreToolUse' && context.toolName === 'Bash') {
@@ -146,7 +146,7 @@ export async function runHook(
  *
  * @example
  * ```typescript
- * import { runTestHook } from '@outfitter/execution';
+ * import { runTestHook } from '@carabiner/execution';
  *
  * const result = await runTestHook(
  *   async (context) => ({ success: true, message: 'Test passed' }),
@@ -189,7 +189,7 @@ export async function runTestHook(
  * @example
  * ```typescript
  * // my-hook.ts
- * import { createRunner } from '@outfitter/execution';
+ * import { createRunner } from '@carabiner/execution';
  *
  * async function myHookHandler(context: HookContext): Promise<HookResult> {
  *   // Hook logic here
@@ -223,7 +223,7 @@ export function createRunner(
  *
  * @example
  * ```typescript
- * import { createTestRunner } from '@outfitter/execution';
+ * import { createTestRunner } from '@carabiner/execution';
  *
  * const testRunner = createTestRunner(myHookHandler, {
  *   collectMetrics: true,
@@ -259,7 +259,7 @@ export function createTestRunner(
  *
  * @example
  * ```typescript
- * import { runTestHooks } from '@outfitter/execution';
+ * import { runTestHooks } from '@carabiner/execution';
  *
  * const results = await runTestHooks(
  *   [securityHook, validationHook, loggingHook],

--- a/packages/hooks-cli/README.md
+++ b/packages/hooks-cli/README.md
@@ -1,6 +1,6 @@
-# @outfitter/hooks-cli
+# @carabiner/hooks-cli
 
-Command-line tools, scaffolding, and project management for Claude Code hooks.
+Command-line tools, scaffolding, and project management for Carabiner hooks.
 
 ## Installation
 
@@ -8,11 +8,11 @@ Command-line tools, scaffolding, and project management for Claude Code hooks.
 
 # Global installation (recommended)
 
-npm install -g @outfitter/hooks-cli
+npm install -g @carabiner/hooks-cli
 
 # Or use directly with npx
 
-npx @outfitter/hooks-cli --help
+npx @carabiner/hooks-cli --help
 
 ```
 
@@ -24,23 +24,23 @@ npx @outfitter/hooks-cli --help
 
 # Initialize hooks in your project
 
-claude-hooks init
+carabiner init
 
 # Generate a new hook
 
-claude-hooks generate --type PreToolUse --tool Bash --name security-check
+carabiner generate --type PreToolUse --tool Bash --name security-check
 
 # Build and validate configuration
 
-claude-hooks build --output .claude/settings.json
+carabiner build --output .claude/settings.json
 
 # Test a specific hook
 
-claude-hooks test --hook ./hooks/pre-tool-use.ts
+carabiner test --hook ./hooks/pre-tool-use.ts
 
 # Development mode with file watching
 
-claude-hooks dev --watch
+carabiner dev --watch
 
 ```
 
@@ -50,17 +50,17 @@ claude-hooks dev --watch
 
 # Basic initialization
 
-claude-hooks init
+carabiner init
 
 # TypeScript project with strict configuration
 
-claude-hooks init --typescript --strict
+carabiner init --typescript --strict
 
 # Initialize with templates
 
-claude-hooks init --template security
-claude-hooks init --template formatting
-claude-hooks init --template audit
+carabiner init --template security
+carabiner init --template formatting
+carabiner init --template audit
 
 ```
 
@@ -89,10 +89,10 @@ README.md                     # Updated with hook documentation
 
 ### `init`
 
-Initialize Claude Code hooks in your project.
+Initialize Carabiner hooks in your project.
 
 ```bash
-claude-hooks init [options]
+carabiner init [options]
 
 Options:
   --typescript, -t     Generate TypeScript hooks (default: true)
@@ -110,19 +110,19 @@ Options:
 
 # Basic TypeScript setup with Bun
 
-claude-hooks init
+carabiner init
 
 # JavaScript with Node.js
 
-claude-hooks init --javascript --runtime node
+carabiner init --javascript --runtime node
 
 # Security-focused setup
 
-claude-hooks init --template security --strict
+carabiner init --template security --strict
 
 # See what would be created
 
-claude-hooks init --template audit --dry-run
+carabiner init --template audit --dry-run
 
 ```
 
@@ -131,7 +131,7 @@ claude-hooks init --template audit --dry-run
 Generate new hook scripts from templates.
 
 ```bash
-claude-hooks generate [options]
+carabiner generate [options]
 
 Options:
   --type <event>       Hook event (PreToolUse, PostToolUse, SessionStart, etc.)
@@ -149,23 +149,23 @@ Options:
 
 # Universal security hook for all tools
 
-claude-hooks generate --type PreToolUse --name universal-security
+carabiner generate --type PreToolUse --name universal-security
 
 # Bash-specific security hook
 
-claude-hooks generate --type PreToolUse --tool Bash --name bash-security
+carabiner generate --type PreToolUse --tool Bash --name bash-security
 
 # Post-write formatting hook
 
-claude-hooks generate --type PostToolUse --tool Write --name format-after-write
+carabiner generate --type PostToolUse --tool Write --name format-after-write
 
 # Session audit hook
 
-claude-hooks generate --type SessionStart --name session-audit
+carabiner generate --type SessionStart --name session-audit
 
 # Use template with custom name
 
-claude-hooks generate --type PreToolUse --template security --name custom-security
+carabiner generate --type PreToolUse --template security --name custom-security
 
 ```
 
@@ -182,7 +182,7 @@ Generated files include:
 Build and validate hook configuration for Claude Code.
 
 ```bash
-claude-hooks build [options]
+carabiner build [options]
 
 Options:
   --config <path>      Configuration file (default: .claude/hooks.config.ts)
@@ -199,19 +199,19 @@ Options:
 
 # Build default configuration
 
-claude-hooks build
+carabiner build
 
 # Build for production environment
 
-claude-hooks build --environment production --output .claude/settings.prod.json
+carabiner build --environment production --output .claude/settings.prod.json
 
 # Build with validation and minification
 
-claude-hooks build --validate --minify
+carabiner build --validate --minify
 
 # Watch mode for development
 
-claude-hooks build --watch
+carabiner build --watch
 
 ```
 
@@ -220,7 +220,7 @@ claude-hooks build --watch
 Test hooks with mock data or run validation checks.
 
 ```bash
-claude-hooks test [options] [hook-file...]
+carabiner test [options] [hook-file...]
 
 Options:
   --hook <path>        Specific hook file to test
@@ -238,23 +238,23 @@ Options:
 
 # Test all hooks
 
-claude-hooks test
+carabiner test
 
 # Test specific hook file
 
-claude-hooks test --hook ./hooks/bash-security.ts
+carabiner test --hook ./hooks/bash-security.ts
 
 # Test with specific tool context
 
-claude-hooks test --hook ./hooks/pre-tool-use.ts --tool Bash --input '{"command":"ls -la"}'
+carabiner test --hook ./hooks/pre-tool-use.ts --tool Bash --input '{"command":"ls -la"}'
 
 # Test PreToolUse event with mock data
 
-claude-hooks test --event PreToolUse --tool Write --input '{"file_path":"test.txt","content":"hello"}'
+carabiner test --event PreToolUse --tool Write --input '{"file_path":"test.txt","content":"hello"}'
 
 # Validate without execution
 
-claude-hooks test --dry-run --verbose
+carabiner test --dry-run --verbose
 
 ```
 
@@ -263,7 +263,7 @@ claude-hooks test --dry-run --verbose
 Development mode with file watching and hot reload.
 
 ```bash
-claude-hooks dev [options]
+carabiner dev [options]
 
 Options:
   --watch              Watch hook files for changes (default: true)
@@ -280,15 +280,15 @@ Options:
 
 # Basic development mode
 
-claude-hooks dev
+carabiner dev
 
 # Watch with testing and rebuilding
 
-claude-hooks dev --test-on-change --build-on-change
+carabiner dev --test-on-change --build-on-change
 
 # Development server with UI
 
-claude-hooks dev --port 3001 --open
+carabiner dev --port 3001 --open
 
 ```
 
@@ -297,7 +297,7 @@ claude-hooks dev --port 3001 --open
 Manage hook configuration.
 
 ```bash
-claude-hooks config <command> [options]
+carabiner config <command> [options]
 
 Commands:
   get <key>            Get configuration value
@@ -315,31 +315,31 @@ Commands:
 
 # List all hook configurations
 
-claude-hooks config list
+carabiner config list
 
 # Get specific hook configuration
 
-claude-hooks config get PreToolUse.Bash
+carabiner config get PreToolUse.Bash
 
 # Set hook configuration
 
-claude-hooks config set PreToolUse.Bash.timeout 10000
+carabiner config set PreToolUse.Bash.timeout 10000
 
 # Remove hook
 
-claude-hooks config remove PostToolUse.Write
+carabiner config remove PostToolUse.Write
 
 # Validate configuration
 
-claude-hooks config validate
+carabiner config validate
 
 # Create backup
 
-claude-hooks config backup
+carabiner config backup
 
 # Restore from backup
 
-claude-hooks config restore .claude/backups/settings-2024-01-15.json
+carabiner config restore .claude/backups/settings-2024-01-15.json
 
 ```
 
@@ -348,7 +348,7 @@ claude-hooks config restore .claude/backups/settings-2024-01-15.json
 Validate hooks and configuration.
 
 ```bash
-claude-hooks validate [options]
+carabiner validate [options]
 
 Options:
   --config             Validate configuration files
@@ -366,19 +366,19 @@ Options:
 
 # Validate everything
 
-claude-hooks validate
+carabiner validate
 
 # Validate only configuration
 
-claude-hooks validate --config
+carabiner validate --config
 
 # Syntax and type checking only
 
-claude-hooks validate --syntax --types
+carabiner validate --syntax --types
 
 # Security-focused validation
 
-claude-hooks validate --security
+carabiner validate --security
 
 ```
 
@@ -387,8 +387,8 @@ claude-hooks validate --security
 Create a `hooks.config.ts` file for advanced configuration:
 
 ```typescript
-import { defineConfig } from '@outfitter/hooks-cli';
-import { templates } from '@outfitter/hooks-config';
+import { defineConfig } from '@carabiner/hooks-cli';
+import { templates } from '@carabiner/hooks-config';
 
 export default defineConfig({
   // Runtime configuration
@@ -486,7 +486,7 @@ export default defineConfig({
 #### Security Template
 
 ```bash
-claude-hooks init --template security
+carabiner init --template security
 
 ```
 
@@ -500,7 +500,7 @@ Creates hooks for:
 #### Formatting Template
 
 ```bash
-claude-hooks init --template formatting
+carabiner init --template formatting
 
 ```
 
@@ -514,7 +514,7 @@ Creates hooks for:
 #### Audit Template
 
 ```bash
-claude-hooks init --template audit
+carabiner init --template audit
 
 ```
 
@@ -528,7 +528,7 @@ Creates hooks for:
 #### Minimal Template
 
 ```bash
-claude-hooks init --template minimal
+carabiner init --template minimal
 
 ```
 
@@ -540,7 +540,7 @@ Create custom templates in `templates/` directory:
 
 ```typescript
 // templates/my-template.ts
-import { defineTemplate } from '@outfitter/hooks-cli';
+import { defineTemplate } from '@carabiner/hooks-cli';
 
 export default defineTemplate({
   name: 'my-template',
@@ -559,7 +559,7 @@ export default defineTemplate({
     {
       path: 'hooks/custom-validator.ts',
       content: `#!/usr/bin/env bun
-import { runClaudeHook, HookResults } from '@outfitter/hooks-core';
+import { runClaudeHook, HookResults } from '@carabiner/hooks-core';
 
 runClaudeHook(async (context) => {
   console.log(\`Custom validation for \${context.toolName}\`);
@@ -568,7 +568,7 @@ runClaudeHook(async (context) => {
     },
   ],
 
-  dependencies: ['@outfitter/hooks-core'],
+  dependencies: ['@carabiner/hooks-core'],
 
   postInstall: async (context) => {
     console.log('Custom template installed successfully!');
@@ -579,7 +579,7 @@ runClaudeHook(async (context) => {
 Use with:
 
 ```bash
-claude-hooks init --template ./templates/my-template.ts
+carabiner init --template ./templates/my-template.ts
 
 ```
 
@@ -592,11 +592,11 @@ Add to your `package.json`:
 ```json
 {
   "scripts": {
-    "hooks:build": "claude-hooks build",
-    "hooks:test": "claude-hooks test",
-    "hooks:dev": "claude-hooks dev",
-    "hooks:validate": "claude-hooks validate",
-    "hooks:init": "claude-hooks init"
+    "hooks:build": "carabiner build",
+    "hooks:test": "carabiner test",
+    "hooks:dev": "carabiner dev",
+    "hooks:validate": "carabiner validate",
+    "hooks:init": "carabiner init"
   }
 }
 ```
@@ -626,9 +626,9 @@ jobs:
 
       - name: Validate hooks
         run: |
-          bunx @outfitter/hooks-cli validate --all
-          bunx @outfitter/hooks-cli test --dry-run
-          bunx @outfitter/hooks-cli build --validate
+          bunx @carabiner/hooks-cli validate --all
+          bunx @carabiner/hooks-cli test --dry-run
+          bunx @carabiner/hooks-cli build --validate
 ```
 
 ### IDE Integration
@@ -640,9 +640,9 @@ The CLI works with the Claude Code VS Code extension:
 ```json
 // .vscode/settings.json
 {
-  "claude-code.hooks.validateOnSave": true,
-  "claude-code.hooks.formatOnSave": true,
-  "claude-code.hooks.showInlineErrors": true
+  "carabiner.hooks.validateOnSave": true,
+  "carabiner.hooks.formatOnSave": true,
+  "carabiner.hooks.showInlineErrors": true
 }
 ```
 
@@ -654,7 +654,7 @@ The CLI generates TypeScript definitions:
 
 ```typescript
 // types/hooks.d.ts (auto-generated)
-import type { HookContext, HookResult } from '@outfitter/hooks-core';
+import type { HookContext, HookResult } from '@carabiner/hooks-core';
 
 export interface ProjectHookContext extends HookContext {
   // Project-specific context extensions
@@ -671,11 +671,11 @@ export interface ProjectHookResult extends HookResult {
 
 # Type check all hooks
 
-claude-hooks validate --types
+carabiner validate --types
 
 # Type check specific hook
 
-claude-hooks validate --types --hook ./hooks/bash-security.ts
+carabiner validate --types --hook ./hooks/bash-security.ts
 
 ```
 
@@ -689,11 +689,11 @@ claude-hooks validate --types --hook ./hooks/bash-security.ts
 
 # Check configuration
 
-claude-hooks config validate
+carabiner config validate
 
 # Test hook directly
 
-claude-hooks test --hook ./hooks/problematic-hook.ts --verbose
+carabiner test --hook ./hooks/problematic-hook.ts --verbose
 
 ```
 
@@ -703,11 +703,11 @@ claude-hooks test --hook ./hooks/problematic-hook.ts --verbose
 
 # Analyze hook performance
 
-claude-hooks validate --performance
+carabiner validate --performance
 
 # Check timeout settings
 
-claude-hooks config get PreToolUse.Bash.timeout
+carabiner config get PreToolUse.Bash.timeout
 
 ```
 
@@ -722,7 +722,7 @@ ls -la hooks/
 # Test with explicit permissions
 
 chmod +x hooks/*.ts
-claude-hooks test
+carabiner test
 
 ```
 
@@ -732,11 +732,11 @@ claude-hooks test
 
 # Enable debug output
 
-DEBUG=claude-hooks:* claude-hooks dev
+DEBUG=carabiner:* carabiner dev
 
 # Verbose logging
 
-claude-hooks test --verbose --hook ./hooks/debug-me.ts
+carabiner test --verbose --hook ./hooks/debug-me.ts
 
 ```
 
@@ -748,29 +748,29 @@ claude-hooks test --verbose --hook ./hooks/debug-me.ts
 
 # 1. Initialize project with security template
 
-claude-hooks init --template security --typescript --strict
+carabiner init --template security --typescript --strict
 
 # 2. Generate additional hooks
 
-claude-hooks generate --type PostToolUse --tool Write --name format-typescript
-claude-hooks generate --type PreToolUse --tool Bash --name dangerous-command-blocker
+carabiner generate --type PostToolUse --tool Write --name format-typescript
+carabiner generate --type PreToolUse --tool Bash --name dangerous-command-blocker
 
 # 3. Configure for different environments
 
-claude-hooks config set environments.production.hooks.PreToolUse.*.timeout 15000
-claude-hooks config set environments.development.hooks.PreToolUse.*.timeout 5000
+carabiner config set environments.production.hooks.PreToolUse.*.timeout 15000
+carabiner config set environments.development.hooks.PreToolUse.*.timeout 5000
 
 # 4. Build production configuration
 
-claude-hooks build --environment production --output .claude/settings.prod.json
+carabiner build --environment production --output .claude/settings.prod.json
 
 # 5. Test everything
 
-claude-hooks test --all
+carabiner test --all
 
 # 6. Start development mode
 
-claude-hooks dev --watch --test-on-change
+carabiner dev --watch --test-on-change
 
 ```
 
@@ -780,10 +780,10 @@ claude-hooks dev --watch --test-on-change
 
 # Generate tool-specific hooks for different scenarios
 
-claude-hooks generate --type PreToolUse --tool Bash --name production-bash-security --template security
-claude-hooks generate --type PreToolUse --tool Write --name file-validation --template validation
-claude-hooks generate --type PostToolUse --tool Edit --name format-and-lint --template formatting
-claude-hooks generate --type SessionStart --name project-initialization
+carabiner generate --type PreToolUse --tool Bash --name production-bash-security --template security
+carabiner generate --type PreToolUse --tool Write --name file-validation --template validation
+carabiner generate --type PostToolUse --tool Edit --name format-and-lint --template formatting
+carabiner generate --type SessionStart --name project-initialization
 
 ```
 
@@ -792,7 +792,7 @@ claude-hooks generate --type SessionStart --name project-initialization
 For programmatic usage:
 
 ```typescript
-import { CLI, ConfigManager, TemplateEngine } from '@outfitter/hooks-cli';
+import { CLI, ConfigManager, TemplateEngine } from '@carabiner/hooks-cli';
 
 // Programmatic CLI usage
 const cli = new CLI();

--- a/packages/hooks-cli/package.json
+++ b/packages/hooks-cli/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@outfitter/hooks-cli",
+  "name": "@carabiner/hooks-cli",
   "version": "0.1.0",
-  "description": "CLI tools for Claude Code hooks development",
+  "description": "CLI tools for Carabiner hooks development",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "claude-hooks": "./dist/cli.js"
+    "carabiner": "./dist/cli.js"
   },
   "exports": {
     ".": {
@@ -32,7 +32,7 @@
     "prepublishOnly": "bun run build"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "cli",
     "development-tools"
@@ -40,9 +40,9 @@
   "author": "Matt Galligan <matt.galligan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/hooks-config": "workspace:*",
-    "@outfitter/hooks-core": "workspace:*",
-    "@outfitter/hooks-validators": "workspace:*"
+    "@carabiner/hooks-config": "workspace:*",
+    "@carabiner/hooks-core": "workspace:*",
+    "@carabiner/hooks-validators": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "*",

--- a/packages/hooks-cli/src/cli.ts
+++ b/packages/hooks-cli/src/cli.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
-import { createCliLogger, type Logger } from '@outfitter/hooks-core';
+import { createCliLogger, type Logger } from '@carabiner/hooks-core';
 import { ConfigCommand } from './commands/config';
 import { GenerateCommand } from './commands/generate';
 // Statically import commands to guarantee inclusion in compiled binary

--- a/packages/hooks-cli/src/commands/config.ts
+++ b/packages/hooks-cli/src/commands/config.ts
@@ -5,8 +5,8 @@
 import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
-import { ConfigManager } from '@outfitter/hooks-config';
-import type { HookEvent, ToolName } from '@outfitter/hooks-core';
+import { ConfigManager } from '@carabiner/hooks-config';
+import type { HookEvent, ToolName } from '@carabiner/hooks-core';
 import { BaseCommand, type CliConfig } from '../types';
 
 // Regex constants for better command parsing

--- a/packages/hooks-cli/src/commands/init.ts
+++ b/packages/hooks-cli/src/commands/init.ts
@@ -5,7 +5,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { DEFAULT_CONFIG } from '@outfitter/hooks-config';
+import { DEFAULT_CONFIG } from '@carabiner/hooks-config';
 import { BaseCommand, type CliConfig } from '../types';
 
 export class InitCommand extends BaseCommand {
@@ -177,9 +177,9 @@ export class InitCommand extends BaseCommand {
     const typesContent = (useTypeScript: boolean) =>
       useTypeScript
         ? `
-export * from '@outfitter/hooks-core';
-export * from '@outfitter/hooks-validators';
-export * from '@outfitter/hooks-config';
+export * from '@carabiner/hooks-core';
+export * from '@carabiner/hooks-validators';
+export * from '@carabiner/hooks-config';
 
 // Custom types for your hooks
 export interface CustomHookData {
@@ -333,8 +333,8 @@ module.exports = { HookUtils };
     const advancedContent =
       extension === 'ts'
         ? `
-import { HookBuilder, middleware } from '@outfitter/hooks-core';
-import { SecurityValidators } from '@outfitter/hooks-validators';
+import { HookBuilder, middleware } from '@carabiner/hooks-core';
+import { SecurityValidators } from '@carabiner/hooks-validators';
 
 // Example of advanced hook composition
 export const advancedPreToolUse = HookBuilder
@@ -373,8 +373,8 @@ export const advancedPreToolUse = HookBuilder
     const securityContent =
       extension === 'ts'
         ? `
-import { SecurityValidators, validateHookSecurity } from '@outfitter/hooks-validators';
-import type { HookContext, HookResult } from '@outfitter/hooks-core';
+import { SecurityValidators, validateHookSecurity } from '@carabiner/hooks-validators';
+import type { HookContext, HookResult } from '@carabiner/hooks-core';
 
 /**
  * Security-focused hook handler
@@ -429,7 +429,7 @@ export async function securityHookHandler(context: HookContext): Promise<HookRes
       extension === 'ts'
         ? `
 import { test, expect } from 'bun:test';
-import { createMockContextFor, TestUtils } from '@outfitter/hooks-testing';
+import { createMockContextFor, TestUtils } from '@carabiner/hooks-testing';
 import { handlePreToolUse } from '../pre-tool-use.ts';
 
 test('PreToolUse hook should validate safe commands', async () => {
@@ -531,9 +531,9 @@ const { test, expect } = require('bun:test');
     if (isTypeScript) {
       return `#!/usr/bin/env bun
 
-import { createHookContext, exitWithResult, HookResults } from '@outfitter/hooks-core';
-import { validateHookSecurity } from '@outfitter/hooks-validators';
-import type { HookResult } from '@outfitter/hooks-core';
+import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
+import { validateHookSecurity } from '@carabiner/hooks-validators';
+import type { HookResult } from '@carabiner/hooks-core';
 
 /**
  * PreToolUse hook - validates tool usage before execution
@@ -572,8 +572,8 @@ export { handlePreToolUse };
     }
     return `#!/usr/bin/env bun
 
-const { createHookContext, exitWithResult, HookResults } = require('@outfitter/hooks-core');
-const { validateHookSecurity } = require('@outfitter/hooks-validators');
+const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
+const { validateHookSecurity } = require('@carabiner/hooks-validators');
 
 /**
  * PreToolUse hook - validates tool usage before execution
@@ -618,8 +618,8 @@ module.exports = { handlePreToolUse };
     if (isTypeScript) {
       return `#!/usr/bin/env bun
 
-import { createHookContext, exitWithResult, HookResults } from '@outfitter/hooks-core';
-import type { HookResult } from '@outfitter/hooks-core';
+import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
+import type { HookResult } from '@carabiner/hooks-core';
 
 /**
  * PostToolUse hook - performs actions after tool execution
@@ -651,7 +651,7 @@ export { handlePostToolUse };
     }
     return `#!/usr/bin/env bun
 
-const { createHookContext, exitWithResult, HookResults } = require('@outfitter/hooks-core');
+const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
 
 /**
  * PostToolUse hook - performs actions after tool execution
@@ -689,8 +689,8 @@ module.exports = { handlePostToolUse };
     if (isTypeScript) {
       return `#!/usr/bin/env bun
 
-import { createHookContext, exitWithResult, HookResults } from '@outfitter/hooks-core';
-import type { HookResult } from '@outfitter/hooks-core';
+import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
+import type { HookResult } from '@carabiner/hooks-core';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -744,7 +744,7 @@ export { handleSessionStart };
     }
     return `#!/usr/bin/env bun
 
-const { createHookContext, exitWithResult, HookResults } = require('@outfitter/hooks-core');
+const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
 const { existsSync, readFileSync } = require('node:fs');
 const { join } = require('node:path');
 

--- a/packages/hooks-cli/src/commands/validate.ts
+++ b/packages/hooks-cli/src/commands/validate.ts
@@ -8,8 +8,8 @@ import { join } from 'node:path';
 import {
   type ExtendedHookConfiguration,
   loadConfig,
-} from '@outfitter/hooks-config';
-import type { ToolHookConfig } from '@outfitter/hooks-core';
+} from '@carabiner/hooks-config';
+import type { ToolHookConfig } from '@carabiner/hooks-core';
 import { BaseCommand, type CliConfig } from '../types';
 
 // Regex patterns at top level
@@ -393,7 +393,7 @@ export class ValidateCommand extends BaseCommand {
 
       // Check for basic imports (TypeScript/JavaScript)
       const hasImports =
-        content.includes('@outfitter/hooks-core') ||
+        content.includes('@carabiner/hooks-core') ||
         content.includes('require(') ||
         content.includes('import');
 

--- a/packages/hooks-cli/src/security/__tests__/security.test.ts
+++ b/packages/hooks-cli/src/security/__tests__/security.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { SecurityValidationError } from '@outfitter/hooks-validators';
+import { SecurityValidationError } from '@carabiner/hooks-validators';
 import { CommandValidator, validateCommand } from '../command-validator';
 import { createWorkspaceValidator } from '../workspace-validator';
 

--- a/packages/hooks-cli/src/security/command-validator.ts
+++ b/packages/hooks-cli/src/security/command-validator.ts
@@ -3,7 +3,7 @@
  * Provides comprehensive security validation for CLI commands and hook execution
  */
 
-import { SecurityValidationError } from '@outfitter/hooks-validators';
+import { SecurityValidationError } from '@carabiner/hooks-validators';
 
 /**
  * Command security configuration

--- a/packages/hooks-cli/src/security/index.ts
+++ b/packages/hooks-cli/src/security/index.ts
@@ -8,7 +8,7 @@ import { CommandValidator } from './command-validator';
 import { createWorkspaceValidator } from './workspace-validator';
 
 // Re-export security validation error for convenience
-export { SecurityValidationError } from '@outfitter/hooks-validators';
+export { SecurityValidationError } from '@carabiner/hooks-validators';
 
 // Command validation
 export {

--- a/packages/hooks-cli/src/security/workspace-validator.ts
+++ b/packages/hooks-cli/src/security/workspace-validator.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, lstatSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
-import { SecurityValidationError } from '@outfitter/hooks-validators';
+import { SecurityValidationError } from '@carabiner/hooks-validators';
 
 /**
  * Workspace security configuration

--- a/packages/hooks-cli/src/templates/hook/basic.ts
+++ b/packages/hooks-cli/src/templates/hook/basic.ts
@@ -4,7 +4,7 @@
 
 export const basicHookTypeScript = (name: string): string => `#!/usr/bin/env bun
 
-import { runClaudeHook, HookResults, type HookContext } from '@outfitter/hooks-core';
+import { runClaudeHook, HookResults, type HookContext } from '@carabiner/hooks-core';
 
 async function handler(ctx: HookContext) {
   console.log(\`${name} hook triggered for: \${ctx.toolName}\`);
@@ -29,7 +29,7 @@ export { handler };
 
 export const basicHookJavaScript = (name: string): string => `#!/usr/bin/env bun
 
-const { runClaudeHook, HookResults } = require('@outfitter/hooks-core');
+const { runClaudeHook, HookResults } = require('@carabiner/hooks-core');
 
 async function handler(ctx) {
   console.log(\`${name} hook triggered for: \${ctx.toolName}\`);

--- a/packages/hooks-cli/src/templates/hook/security.ts
+++ b/packages/hooks-cli/src/templates/hook/security.ts
@@ -6,8 +6,8 @@ export const securityHookTypeScript = (
   name: string
 ): string => `#!/usr/bin/env bun
 
-import { runClaudeHook, HookResults, type HookContext } from '@outfitter/hooks-core';
-import { SecurityValidators } from '@outfitter/hooks-validators';
+import { runClaudeHook, HookResults, type HookContext } from '@carabiner/hooks-core';
+import { SecurityValidators } from '@carabiner/hooks-validators';
 
 async function handler(ctx: HookContext) {
   console.log(\`🔒 ${name} security hook triggered for: \${ctx.toolName}\`);
@@ -76,8 +76,8 @@ export const securityHookJavaScript = (
   name: string
 ): string => `#!/usr/bin/env bun
 
-const { runClaudeHook, HookResults } = require('@outfitter/hooks-core');
-const { SecurityValidators } = require('@outfitter/hooks-validators');
+const { runClaudeHook, HookResults } = require('@carabiner/hooks-core');
+const { SecurityValidators } = require('@carabiner/hooks-validators');
 
 async function handler(ctx) {
   console.log(\`🔒 ${name} security hook triggered for: \${ctx.toolName}\`);

--- a/packages/hooks-cli/src/templates/hook/validation.ts
+++ b/packages/hooks-cli/src/templates/hook/validation.ts
@@ -6,8 +6,8 @@ export const validationHookTypeScript = (
   name: string
 ): string => `#!/usr/bin/env bun
 
-import { runClaudeHook, HookResults, type HookContext } from '@outfitter/hooks-core';
-import { validateHookContext } from '@outfitter/hooks-validators';
+import { runClaudeHook, HookResults, type HookContext } from '@carabiner/hooks-core';
+import { validateHookContext } from '@carabiner/hooks-validators';
 
 async function handler(ctx: HookContext) {
   console.log(\`${name} hook triggered for: \${ctx.toolName}\`);
@@ -65,8 +65,8 @@ export const validationHookJavaScript = (
   name: string
 ): string => `#!/usr/bin/env bun
 
-const { runClaudeHook, HookResults } = require('@outfitter/hooks-core');
-const { validateHookContext } = require('@outfitter/hooks-validators');
+const { runClaudeHook, HookResults } = require('@carabiner/hooks-core');
+const { validateHookContext } = require('@carabiner/hooks-validators');
 
 async function handler(ctx) {
   console.log(\`${name} hook triggered for: \${ctx.toolName}\`);

--- a/packages/hooks-cli/src/templates/middleware/index.ts
+++ b/packages/hooks-cli/src/templates/middleware/index.ts
@@ -8,7 +8,7 @@ export const middlewareTypeScript = (name: string): string => `/**
  * Custom middleware: ${name}
  */
 
-import type { HookMiddleware, HookContext, HookResult } from '@outfitter/hooks-core';
+import type { HookMiddleware, HookContext, HookResult } from '@carabiner/hooks-core';
 
 /**
  * ${pascalCase(name)} middleware

--- a/packages/hooks-cli/src/templates/test/index.ts
+++ b/packages/hooks-cli/src/templates/test/index.ts
@@ -12,7 +12,7 @@ import {
   createMockContextFor,
   TestUtils,
   mockEnv
-} from '@outfitter/hooks-testing';
+} from '@carabiner/hooks-testing';
 import { handle${pascalCase(name)} } from '../${name}.ts';
 
 describe('${name} hook tests', () => {
@@ -102,7 +102,7 @@ const {
   createMockContextFor,
   TestUtils,
   mockEnv
-} = require('@outfitter/hooks-testing');
+} = require('@carabiner/hooks-testing');
 const { handle${pascalCase(name)} } = require('../${name}.js');
 
 describe('${name} hook tests', () => {

--- a/packages/hooks-cli/src/templates/validator/index.ts
+++ b/packages/hooks-cli/src/templates/validator/index.ts
@@ -8,8 +8,8 @@ export const validatorTypeScript = (name: string): string => `/**
  * Custom validator: ${name}
  */
 
-import type { HookContext, ValidationResult } from '@outfitter/hooks-core';
-import { ValidationError } from '@outfitter/hooks-validators';
+import type { HookContext, ValidationResult } from '@carabiner/hooks-core';
+import { ValidationError } from '@carabiner/hooks-validators';
 
 const SESSION_ID_REGEX = /^[a-zA-Z0-9-]+$/;
 
@@ -96,7 +96,7 @@ export const validatorJavaScript = (name: string): string => `/**
  * Custom validator: ${name}
  */
 
-const { ValidationError } = require('@outfitter/hooks-validators');
+const { ValidationError } = require('@carabiner/hooks-validators');
 
 const SESSION_ID_REGEX = /^[a-zA-Z0-9-]+$/;
 

--- a/packages/hooks-config/README.md
+++ b/packages/hooks-config/README.md
@@ -1,6 +1,6 @@
 # @outfitter/hooks-config
 
-Configuration management and settings generation for Claude Code hooks.
+Configuration management and settings generation for Carabiner hooks.
 
 ## Installation
 

--- a/packages/hooks-config/package.json
+++ b/packages/hooks-config/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/hooks-config",
+  "name": "@carabiner/hooks-config",
   "version": "0.1.0",
-  "description": "Configuration management for Claude Code hooks",
+  "description": "Configuration management for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,15 +28,15 @@
     "prepublishOnly": "bun run build"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "configuration"
   ],
   "author": "Matt Galligan <matt.galligan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/hooks-core": "workspace:*",
-    "@outfitter/error-management": "workspace:*"
+    "@carabiner/hooks-core": "workspace:*",
+    "@carabiner/error-management": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "*",

--- a/packages/hooks-config/src/config.ts
+++ b/packages/hooks-config/src/config.ts
@@ -10,7 +10,7 @@ import type {
   HookEvent,
   ToolHookConfig,
   ToolName,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 // Note: Error management lives in a separate package. To avoid build-order
 // coupling here, we use a local error type and keep integration optional.
 
@@ -90,7 +90,7 @@ export const CONFIG_PATHS = {
  * Default hook configuration
  */
 export const DEFAULT_CONFIG: ExtendedHookConfiguration = {
-  $schema: 'https://claude-code-hooks.dev/schema.json',
+  $schema: 'https://carabiner.outfitter.dev/schema.json',
   version: '1.0.0',
 
   PreToolUse: {
@@ -225,7 +225,7 @@ export class ConfigManager {
       return await op();
     }
     try {
-      const em = await import('@outfitter/error-management');
+      const em = await import('@carabiner/error-management');
       return await em.executeWithBoundary(
         op,
         boundaryName,
@@ -308,7 +308,7 @@ export class ConfigManager {
       // Optionally report via error-management if available
       if (this.advancedErrorManagementEnabled) {
         try {
-          const em = await import('@outfitter/error-management');
+          const em = await import('@carabiner/error-management');
           await em.reportError(
             new em.ConfigurationError(
               `Failed to load configuration: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -387,7 +387,7 @@ export class ConfigManager {
     } catch (error) {
       if (this.advancedErrorManagementEnabled) {
         try {
-          const em = await import('@outfitter/error-management');
+          const em = await import('@carabiner/error-management');
           await em.reportError(
             new em.ConfigurationError(
               `Failed to save configuration: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -813,7 +813,7 @@ export class ConfigManager {
   private generateJSConfig(config: ExtendedHookConfiguration): string {
     return `/**
  * Claude Code hooks configuration
- * @type {import('@outfitter/hooks-config').ExtendedHookConfiguration}
+ * @type {import('@carabiner/hooks-config').ExtendedHookConfiguration}
  */
 module.exports = ${JSON.stringify(config, null, 2)};
 `;
@@ -823,7 +823,7 @@ module.exports = ${JSON.stringify(config, null, 2)};
    * Generate TypeScript config content
    */
   private generateTSConfig(config: ExtendedHookConfiguration): string {
-    return `import type { ExtendedHookConfiguration } from '@outfitter/hooks-config';
+    return `import type { ExtendedHookConfiguration } from '@carabiner/hooks-config';
 
 /**
  * Claude Code hooks configuration

--- a/packages/hooks-config/src/types/error-management.d.ts
+++ b/packages/hooks-config/src/types/error-management.d.ts
@@ -1,4 +1,4 @@
-declare module '@outfitter/error-management' {
+declare module '@carabiner/error-management' {
   export const ErrorCode: Record<string, number>;
   export class ConfigurationError extends Error {
     constructor(message: string, code?: number, details?: unknown);

--- a/packages/hooks-core/README.md
+++ b/packages/hooks-core/README.md
@@ -1,6 +1,6 @@
 # @outfitter/hooks-core
 
-Core types, runtime utilities, and execution engine for Claude Code hooks TypeScript library.
+Core types, runtime utilities, and execution engine for Carabiner hooks TypeScript library.
 
 ## Installation
 

--- a/packages/hooks-core/package.json
+++ b/packages/hooks-core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/hooks-core",
+  "name": "@carabiner/hooks-core",
   "version": "0.2.0",
-  "description": "Core TypeScript types and runtime utilities for Claude Code hooks",
+  "description": "Core TypeScript types and runtime utilities for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -36,7 +36,7 @@
     "prepublishOnly": "bun run build"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "typescript",
     "types"

--- a/packages/hooks-core/src/__tests__/runtime.test.ts
+++ b/packages/hooks-core/src/__tests__/runtime.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createTestContext } from '@outfitter/types';
+import { createTestContext } from '@carabiner/types';
 import {
   createBashContext,
   createFileContext,

--- a/packages/hooks-testing/README.md
+++ b/packages/hooks-testing/README.md
@@ -1,6 +1,6 @@
 # @outfitter/hooks-testing
 
-Testing framework, mocks, and utilities for Claude Code hooks.
+Testing framework, mocks, and utilities for Carabiner hooks.
 
 ## Installation
 

--- a/packages/hooks-testing/package.json
+++ b/packages/hooks-testing/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/hooks-testing",
+  "name": "@carabiner/hooks-testing",
   "version": "0.1.0",
-  "description": "Testing utilities for Claude Code hooks",
+  "description": "Testing utilities for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "prepublishOnly": "bun run build"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "testing",
     "utilities"
@@ -36,8 +36,8 @@
   "author": "Matt Galligan <matt.galligan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/hooks-core": "workspace:*",
-    "@outfitter/hooks-validators": "workspace:*"
+    "@carabiner/hooks-core": "workspace:*",
+    "@carabiner/hooks-validators": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "*",

--- a/packages/hooks-testing/src/mock.ts
+++ b/packages/hooks-testing/src/mock.ts
@@ -12,7 +12,7 @@ import type {
   HookEvent,
   ToolInput,
   ToolName,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 
 /**
  * Mock environment configuration

--- a/packages/hooks-testing/src/test-framework.ts
+++ b/packages/hooks-testing/src/test-framework.ts
@@ -7,8 +7,8 @@ import type {
   HookContext,
   HookHandler,
   HookResult,
-} from '@outfitter/hooks-core';
-import { executeHook } from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
+import { executeHook } from '@carabiner/hooks-core';
 import type { MockEnvironmentConfig } from './mock';
 import { mockEnv } from './mock';
 

--- a/packages/hooks-validators/README.md
+++ b/packages/hooks-validators/README.md
@@ -1,6 +1,6 @@
 # @outfitter/hooks-validators
 
-Security validators and environment-specific validation rules for Claude Code hooks.
+Security validators and environment-specific validation rules for Carabiner hooks.
 
 ## Installation
 

--- a/packages/hooks-validators/package.json
+++ b/packages/hooks-validators/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/hooks-validators",
+  "name": "@carabiner/hooks-validators",
   "version": "0.1.0",
-  "description": "Security and validation utilities for Claude Code hooks",
+  "description": "Security and validation utilities for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "prepublishOnly": "bun run build"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "validation",
     "security"
@@ -36,7 +36,7 @@
   "author": "Matt Galligan <matt.galligan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/hooks-core": "workspace:*"
+    "@carabiner/hooks-core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "*",

--- a/packages/hooks-validators/src/security.ts
+++ b/packages/hooks-validators/src/security.ts
@@ -4,12 +4,12 @@
  */
 
 import { extname, relative, resolve } from 'node:path';
-import type { HookContext } from '@outfitter/hooks-core';
+import type { HookContext } from '@carabiner/hooks-core';
 import {
   isBashToolInput,
   isEditToolInput,
   isWriteToolInput,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 
 // Regex patterns defined at module level for performance
 const DYNAMIC_REQUIRE_PATTERN = /require\s*\(\s*[^"'][^)]*[^"']\s*\)/;

--- a/packages/hooks-validators/src/validation.ts
+++ b/packages/hooks-validators/src/validation.ts
@@ -5,13 +5,13 @@
 
 import { existsSync, statSync } from 'node:fs';
 import { dirname, extname, resolve } from 'node:path';
-import type { HookContext, ToolInput, ToolName } from '@outfitter/hooks-core';
+import type { HookContext, ToolInput, ToolName } from '@carabiner/hooks-core';
 import {
   isBashToolInput,
   isEditToolInput,
   isMultiEditToolInput,
   isWriteToolInput,
-} from '@outfitter/hooks-core';
+} from '@carabiner/hooks-core';
 
 /**
  * Validation error class

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -1,6 +1,6 @@
 # @outfitter/plugins
 
-Example plugin collection for Claude Code hooks - demonstrates plugin architecture patterns and best practices.
+Example plugin collection for Carabiner hooks - demonstrates plugin architecture patterns and best practices.
 
 ## Overview
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/plugins",
+  "name": "@carabiner/plugins",
   "version": "1.0.0",
-  "description": "Example plugin collection for Claude Code hooks - demonstrates plugin architecture patterns",
+  "description": "Example plugin collection for Carabiner hooks - demonstrates plugin architecture patterns",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -42,7 +42,7 @@
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "plugins",
     "examples",
@@ -60,9 +60,9 @@
     "directory": "packages/plugins"
   },
   "dependencies": {
-    "@outfitter/registry": "workspace:*",
-    "@outfitter/types": "workspace:*",
-    "@outfitter/execution": "workspace:*",
+    "@carabiner/registry": "workspace:*",
+    "@carabiner/types": "workspace:*",
+    "@carabiner/execution": "workspace:*",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/plugins/src/__tests__/git-safety.test.ts
+++ b/packages/plugins/src/__tests__/git-safety.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { HookContext } from '@outfitter/types';
+import type { HookContext } from '@carabiner/types';
 import { gitSafetyPlugin } from '../git-safety/index';
 
 const createBashContext = (command: string): HookContext =>

--- a/packages/plugins/src/__tests__/security-scanner.test.ts
+++ b/packages/plugins/src/__tests__/security-scanner.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { HookContext } from '@outfitter/types';
+import type { HookContext } from '@carabiner/types';
 import { securityScannerPlugin } from '../security-scanner/index';
 
 const createBashContext = (command: string): HookContext =>

--- a/packages/plugins/src/audit-logger/index.ts
+++ b/packages/plugins/src/audit-logger/index.ts
@@ -14,9 +14,9 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { hostname, userInfo } from 'node:os';
 import { dirname, join } from 'node:path';
-import type { HookPlugin, PluginResult } from '@outfitter/registry';
-import type { HookContext } from '@outfitter/types';
-import { isBashHookContext, isFileHookContext } from '@outfitter/types';
+import type { HookPlugin, PluginResult } from '@carabiner/registry';
+import type { HookContext } from '@carabiner/types';
+import { isBashHookContext, isFileHookContext } from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/plugins/src/file-backup/index.ts
+++ b/packages/plugins/src/file-backup/index.ts
@@ -16,8 +16,8 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { basename, dirname, extname, join } from 'node:path';
-import type { HookPlugin, PluginResult } from '@outfitter/registry';
-import type { HookContext } from '@outfitter/types';
+import type { HookPlugin, PluginResult } from '@carabiner/registry';
+import type { HookContext } from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/plugins/src/git-safety/index.ts
+++ b/packages/plugins/src/git-safety/index.ts
@@ -7,9 +7,9 @@
  * patterns and allow lists for fine-tuned control.
  */
 
-import type { HookPlugin, PluginResult } from '@outfitter/registry';
-import type { HookContext } from '@outfitter/types';
-import { isBashHookContext } from '@outfitter/types';
+import type { HookPlugin, PluginResult } from '@carabiner/registry';
+import type { HookContext } from '@carabiner/types';
+import { isBashHookContext } from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -14,8 +14,8 @@
  *
  * @example Using Individual Plugins
  * ```typescript
- * import { gitSafetyPlugin, fileBackupPlugin } from '@outfitter/plugins';
- * import { PluginRegistry } from '@outfitter/registry';
+ * import { gitSafetyPlugin, fileBackupPlugin } from '@carabiner/plugins';
+ * import { PluginRegistry } from '@carabiner/registry';
  *
  * const registry = new PluginRegistry();
  * registry.register(gitSafetyPlugin);
@@ -24,8 +24,8 @@
  *
  * @example Using Plugin Collection
  * ```typescript
- * import { createPluginCollection } from '@outfitter/plugins';
- * import { PluginRegistry } from '@outfitter/registry';
+ * import { createPluginCollection } from '@carabiner/plugins';
+ * import { PluginRegistry } from '@carabiner/registry';
  *
  * const plugins = createPluginCollection({
  *   gitSafety: true,
@@ -410,7 +410,7 @@ export const VERSION = '1.0.0';
  * Package metadata
  */
 export const PACKAGE_INFO = {
-  name: '@outfitter/plugins',
+  name: '@carabiner/plugins',
   version: VERSION,
   description: 'Example plugin collection for Claude Code hooks',
   repository: 'https://github.com/outfitter-dev/carabiner',

--- a/packages/plugins/src/performance-monitor/index.ts
+++ b/packages/plugins/src/performance-monitor/index.ts
@@ -10,8 +10,8 @@
  */
 
 import { PerformanceObserver, performance } from 'node:perf_hooks';
-import type { HookPlugin, PluginResult } from '@outfitter/registry';
-import type { HookContext } from '@outfitter/types';
+import type { HookPlugin, PluginResult } from '@carabiner/registry';
+import type { HookContext } from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/plugins/src/security-scanner/index.ts
+++ b/packages/plugins/src/security-scanner/index.ts
@@ -10,8 +10,8 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import type { HookPlugin, PluginResult } from '@outfitter/registry';
-import type { HookContext } from '@outfitter/types';
+import type { HookPlugin, PluginResult } from '@carabiner/registry';
+import type { HookContext } from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/protocol",
+  "name": "@carabiner/protocol",
   "version": "0.1.0",
-  "description": "Protocol abstraction layer for Claude Code hooks I/O",
+  "description": "Protocol abstraction layer for Carabiner hooks I/O",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -23,8 +23,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@outfitter/types": "workspace:*",
-    "@outfitter/schemas": "workspace:*"
+    "@carabiner/types": "workspace:*",
+    "@carabiner/schemas": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/outfitter-dev/grapple/tree/main/packages/protocol#readme",
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "protocol",
     "io",

--- a/packages/protocol/src/interface.ts
+++ b/packages/protocol/src/interface.ts
@@ -5,7 +5,7 @@
  * from specific transport mechanisms like stdin/stdout, HTTP, or testing.
  */
 
-import type { HookContext, HookResult } from '@outfitter/types';
+import type { HookContext, HookResult } from '@carabiner/types';
 
 /**
  * Core protocol interface for Claude Code hooks I/O

--- a/packages/protocol/src/protocols/http.ts
+++ b/packages/protocol/src/protocols/http.ts
@@ -9,7 +9,7 @@
 import {
   parseClaudeHookInput,
   validateAndCreateBrandedInput,
-} from '@outfitter/schemas';
+} from '@carabiner/schemas';
 import type {
   DirectoryPath,
   HookContext,
@@ -19,12 +19,12 @@ import type {
   ToolHookEvent,
   ToolInput,
   TranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import {
   createNotificationContext,
   createToolHookContext,
   createUserPromptContext,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import type { HookProtocol } from '../interface';
 import { ProtocolInputError, ProtocolParseError } from '../interface';
 

--- a/packages/protocol/src/protocols/stdin.ts
+++ b/packages/protocol/src/protocols/stdin.ts
@@ -8,7 +8,7 @@
 import {
   parseClaudeHookInput,
   validateAndCreateBrandedInput,
-} from '@outfitter/schemas';
+} from '@carabiner/schemas';
 import type {
   DirectoryPath,
   HookContext,
@@ -18,12 +18,12 @@ import type {
   ToolHookEvent,
   ToolInput,
   TranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import {
   createNotificationContext,
   createToolHookContext,
   createUserPromptContext,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import type { HookProtocol } from '../interface';
 import {
   ProtocolInputError,
@@ -87,7 +87,7 @@ export class StdinProtocol implements HookProtocol {
         new Error('StdinProtocol has been destroyed')
       );
     }
-    
+
     const timeout = this.options.inputTimeout ?? 30_000;
 
     // Set up for new read operation
@@ -97,7 +97,7 @@ export class StdinProtocol implements HookProtocol {
       const input: string = await new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
         let isCleanedUp = false;
-        
+
         // Store reject function for destroy() to call
         this.pendingReadReject = reject;
 
@@ -127,7 +127,7 @@ export class StdinProtocol implements HookProtocol {
 
           // Clear the timeout
           clearTimeout(timeoutId);
-          
+
           // Clear pending reject reference
           this.pendingReadReject = null;
 
@@ -310,9 +310,9 @@ export class StdinProtocol implements HookProtocol {
     if (this.isDestroyed) {
       return;
     }
-    
+
     this.isDestroyed = true;
-    
+
     // Reject any pending read operation
     if (this.pendingReadReject) {
       const error = new ProtocolInputError(
@@ -322,7 +322,7 @@ export class StdinProtocol implements HookProtocol {
       this.pendingReadReject(error);
       this.pendingReadReject = null;
     }
-    
+
     // Clean up the stream if it exists
     if (this.activeStream) {
       // Pause to stop data flow

--- a/packages/protocol/src/protocols/test.ts
+++ b/packages/protocol/src/protocols/test.ts
@@ -9,7 +9,7 @@
 import {
   parseClaudeHookInput,
   validateAndCreateBrandedInput,
-} from '@outfitter/schemas';
+} from '@carabiner/schemas';
 import type {
   BashToolInput,
   DirectoryPath,
@@ -20,7 +20,7 @@ import type {
   ToolHookEvent,
   ToolInput,
   TranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import {
   createDirectoryPath,
   createNotificationContext,
@@ -28,7 +28,7 @@ import {
   createToolHookContext,
   createTranscriptPath,
   createUserPromptContext,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import type { HookProtocol } from '../interface';
 import { ProtocolParseError } from '../interface';
 

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -1,6 +1,6 @@
 # @outfitter/registry
 
-Plugin registry system for Claude Code hooks - enables composition of small, focused hooks through a plugin architecture.
+Plugin registry system for Carabiner hooks - enables composition of small, focused hooks through a plugin architecture.
 
 ## Features
 

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/registry",
+  "name": "@carabiner/registry",
   "version": "1.0.0",
-  "description": "Plugin registry system for Claude Code hooks - enables composition of small, focused hooks through a plugin architecture",
+  "description": "Plugin registry system for Carabiner hooks - enables composition of small, focused hooks through a plugin architecture",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "plugins",
     "registry",
@@ -35,9 +35,9 @@
     "directory": "packages/registry"
   },
   "dependencies": {
-    "@outfitter/execution": "workspace:*",
-    "@outfitter/types": "workspace:*",
-    "@outfitter/schemas": "workspace:*",
+    "@carabiner/execution": "workspace:*",
+    "@carabiner/types": "workspace:*",
+    "@carabiner/schemas": "workspace:*",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/registry/src/__tests__/integration.test.ts
+++ b/packages/registry/src/__tests__/integration.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { HookContext } from '@outfitter/types';
+import type { HookContext } from '@carabiner/types';
 import type { HookConfig, HookPlugin } from '../index';
 import { ConfigLoader, createPluginSystem, PluginRegistry } from '../index';
 

--- a/packages/registry/src/__tests__/registry.test.ts
+++ b/packages/registry/src/__tests__/registry.test.ts
@@ -12,7 +12,7 @@ import {
   spyOn,
   test,
 } from 'bun:test';
-import type { HookContext } from '@outfitter/types';
+import type { HookContext } from '@carabiner/types';
 import type { HookPlugin, PluginConfig } from '../plugin';
 import { PluginRegistry } from '../registry';
 

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -17,7 +17,7 @@
  *
  * @example Basic Usage
  * ```typescript
- * import { PluginRegistry, PluginLoader } from '@outfitter/registry';
+ * import { PluginRegistry, PluginLoader } from '@carabiner/registry';
  * import { gitSafetyPlugin } from './plugins/git-safety';
  *
  * // Create registry
@@ -32,7 +32,7 @@
  *
  * @example With Configuration
  * ```typescript
- * import { PluginRegistry, ConfigLoader } from '@outfitter/registry';
+ * import { PluginRegistry, ConfigLoader } from '@carabiner/registry';
  *
  * // Load configuration
  * const configLoader = new ConfigLoader();
@@ -47,7 +47,7 @@
  *
  * @example With Plugin Discovery
  * ```typescript
- * import { PluginRegistry, PluginLoader } from '@outfitter/registry';
+ * import { PluginRegistry, PluginLoader } from '@carabiner/registry';
  *
  * // Auto-discover plugins
  * const loader = new PluginLoader({
@@ -134,7 +134,7 @@ export const VERSION = '1.0.0';
  * Package metadata
  */
 export const PACKAGE_INFO = {
-  name: '@outfitter/registry',
+  name: '@carabiner/registry',
   version: VERSION,
   description: 'Plugin registry system for Claude Code hooks',
   repository: 'https://github.com/outfitter-dev/grapple',

--- a/packages/registry/src/plugin.ts
+++ b/packages/registry/src/plugin.ts
@@ -4,7 +4,7 @@
  * Enables composition of small, focused hooks through a plugin architecture.
  */
 
-import type { HookContext, HookEvent, HookResult } from '@outfitter/types';
+import type { HookContext, HookEvent, HookResult } from '@carabiner/types';
 import type { z } from 'zod';
 
 /**

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -4,8 +4,8 @@
  * Provides plugin registration, discovery, priority ordering, and event-based execution.
  */
 
-import type { HookContext, HookResult } from '@outfitter/types';
-// import { ExecutionTimer, MemoryTracker } from '@outfitter/execution';
+import type { HookContext, HookResult } from '@carabiner/types';
+// import { ExecutionTimer, MemoryTracker } from '@carabiner/execution';
 import type {
   HookPlugin,
   PluginCondition,

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/schemas",
+  "name": "@carabiner/schemas",
   "version": "0.1.0",
-  "description": "Zod validation schemas for Claude Code hooks",
+  "description": "Zod validation schemas for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
     "test:watch": "bun test --watch"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "validation",
     "zod",
@@ -44,7 +44,7 @@
   "author": "Matt Galligan <matt@outfitter.dev>",
   "license": "MIT",
   "dependencies": {
-    "@outfitter/types": "workspace:*",
+    "@carabiner/types": "workspace:*",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -24,7 +24,7 @@ export type {
   SessionId,
   ToolName,
   TranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 
 export type {
   ClaudeHookInput,

--- a/packages/schemas/src/input.ts
+++ b/packages/schemas/src/input.ts
@@ -3,7 +3,7 @@
  * Validates the JSON input structure from Claude Code
  */
 
-import { HOOK_EVENTS, type ToolName } from '@outfitter/types';
+import { HOOK_EVENTS, type ToolName } from '@carabiner/types';
 import { z } from 'zod';
 
 /**
@@ -187,7 +187,7 @@ export async function validateAndCreateBrandedInput(input: unknown) {
 
   // Import brands dynamically to avoid circular dependency
   const { createSessionId, createTranscriptPath, createDirectoryPath } =
-    await import('@outfitter/types');
+    await import('@carabiner/types');
 
   return {
     ...parsed,

--- a/packages/schemas/src/tools.ts
+++ b/packages/schemas/src/tools.ts
@@ -16,7 +16,7 @@ import type {
   WebFetchToolInput,
   WebSearchToolInput,
   WriteToolInput,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import { z } from 'zod';
 
 /**

--- a/packages/schemas/src/validation.ts
+++ b/packages/schemas/src/validation.ts
@@ -3,13 +3,13 @@
  * Combines Zod schemas with branded type validation
  */
 
-import type { ToolName } from '@outfitter/types';
+import type { ToolName } from '@carabiner/types';
 import {
   BrandValidationError,
   createDirectoryPath,
   createSessionId,
   createTranscriptPath,
-} from '@outfitter/types';
+} from '@carabiner/types';
 import type { z } from 'zod';
 import { type ClaudeHookInput, safeParseClaudeHookInput } from './input.js';
 import { safeValidateToolInput, toolInputSchemas } from './tools.js';
@@ -57,10 +57,10 @@ export type ValidationResult<T> = {
  */
 export type ValidatedClaudeInput = {
   readonly original: ClaudeHookInput;
-  readonly sessionId: import('@outfitter/types').SessionId;
-  readonly transcriptPath: import('@outfitter/types').TranscriptPath;
-  readonly cwd: import('@outfitter/types').DirectoryPath;
-  readonly event: import('@outfitter/types').HookEvent;
+  readonly sessionId: import('@carabiner/types').SessionId;
+  readonly transcriptPath: import('@carabiner/types').TranscriptPath;
+  readonly cwd: import('@carabiner/types').DirectoryPath;
+  readonly event: import('@carabiner/types').HookEvent;
   readonly matcher?: string;
 };
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outfitter/types",
+  "name": "@carabiner/types",
   "version": "0.1.0",
-  "description": "Type system foundation for Claude Code hooks",
+  "description": "Type system foundation for Carabiner hooks",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
     "test:watch": "bun test --watch"
   },
   "keywords": [
-    "claude-code",
+    "carabiner",
     "hooks",
     "typescript",
     "types",

--- a/tests/error-paths/comprehensive-error-handling.test.ts
+++ b/tests/error-paths/comprehensive-error-handling.test.ts
@@ -11,7 +11,7 @@ import type {
   HookContext,
   HookHandler,
   HookResult,
-} from '@outfitter/types';
+} from '@carabiner/types';
 
 /**
  * Error simulation utilities

--- a/tests/integration/cross-package-integration.test.ts
+++ b/tests/integration/cross-package-integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import type { HookConfiguration } from '@outfitter/types';
+import type { HookConfiguration } from '@carabiner/types';
 
 /**
  * Test workspace for integration tests
@@ -129,7 +129,7 @@ describe('Cross-Package Integration Tests', () => {
 
     test('should load and validate configuration through hooks-config', async () => {
       // Test loading config through the config package
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       const config = {
         version: '1.0.0',
@@ -177,8 +177,8 @@ describe('Cross-Package Integration Tests', () => {
 
     test('should execute hooks through hooks-core runtime', async () => {
       // Test the complete execution flow
-      const { HookExecutor } = await import('@outfitter/execution');
-      const { TestProtocol } = await import('@outfitter/protocol');
+      const { HookExecutor } = await import('@carabiner/execution');
+      const { TestProtocol } = await import('@carabiner/protocol');
 
       // Create a simple hook
       const hookContent = `
@@ -214,7 +214,7 @@ export default async function(context) {
 
   describe('Configuration Validation Integration', () => {
     test('should validate complete hook configuration', async () => {
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       const validConfig: HookConfiguration = {
         version: '1.0.0',
@@ -250,7 +250,7 @@ export default async function(context) {
     });
 
     test('should reject invalid configuration', async () => {
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       const invalidConfig = {
         version: '1.0.0',
@@ -274,9 +274,9 @@ export default async function(context) {
   describe('End-to-End Hook Execution', () => {
     test('should execute complete hook workflow with metrics', async () => {
       // Test the complete flow from configuration loading to hook execution
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
       const { globalMetrics, clearExecutionMetrics, getExecutionStats } =
-        await import('@outfitter/execution');
+        await import('@carabiner/execution');
 
       // Clear any existing metrics
       clearExecutionMetrics();
@@ -355,7 +355,7 @@ export default async function(context) {
     });
 
     test('should handle hook execution errors gracefully', async () => {
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       // Create a failing hook
       const failingHookContent = `
@@ -413,7 +413,7 @@ export default async function(context) {
 
   describe('Security Integration Tests', () => {
     test('should enforce security policies across packages', async () => {
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       // Test configuration with potentially unsafe settings
       const unsafeConfig = {
@@ -438,7 +438,7 @@ export default async function(context) {
     });
 
     test('should validate environment variable safety', async () => {
-      const { ConfigManager } = await import('@outfitter/hooks-config');
+      const { ConfigManager } = await import('@carabiner/hooks-config');
 
       const configWithUnsafeEnv: HookConfiguration = {
         version: '1.0.0',
@@ -472,7 +472,7 @@ export default async function(context) {
   describe('Performance Integration', () => {
     test('should track performance across package boundaries', async () => {
       const { globalMetrics, clearExecutionMetrics } = await import(
-        '@outfitter/execution'
+        '@carabiner/execution'
       );
 
       // Clear existing metrics

--- a/tests/performance/benchmarks.test.ts
+++ b/tests/performance/benchmarks.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import type { HookContext, HookHandler, HookResult } from '@outfitter/types';
+import type { HookContext, HookHandler, HookResult } from '@carabiner/types';
 
 /**
  * Performance measurement utilities

--- a/tests/production/production-scenarios.test.ts
+++ b/tests/production/production-scenarios.test.ts
@@ -37,7 +37,7 @@ import {
 } from 'node:fs';
 import { arch, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { HookConfiguration } from '@outfitter/types';
+import type { HookConfiguration } from '@carabiner/types';
 
 /**
  * Production environment simulator
@@ -130,7 +130,7 @@ class ProductionEnvironment {
   createProductionHooks(): void {
     // Security scanner hook
     const securityHook = `
-import type { HookContext, HookResult } from '@outfitter/types';
+import type { HookContext, HookResult } from '@carabiner/types';
 
 export default async function securityScanner(context: HookContext): Promise<HookResult> {
   const startTime = Date.now();
@@ -226,7 +226,7 @@ async function scanForThreats(input: any): Promise<{passed: boolean; reason?: st
 
     // Audit logger hook
     const auditHook = `
-import type { HookContext, HookResult } from '@outfitter/types';
+import type { HookContext, HookResult } from '@carabiner/types';
 
 export default async function auditLogger(context: HookContext): Promise<HookResult> {
   const timestamp = new Date().toISOString();
@@ -489,7 +489,7 @@ console.log(JSON.stringify({
 
       // Test logging functionality by verifying logger can be created
       // and has expected interface
-      const { executionLogger } = await import('@outfitter/hooks-core');
+      const { executionLogger } = await import('@carabiner/hooks-core');
       expect(executionLogger).toBeDefined();
       expect(typeof executionLogger.info).toBe('function');
       expect(typeof executionLogger.error).toBe('function');


### PR DESCRIPTION
- Update all package names from @outfitter/* to @carabiner/*
- Change CLI binary name from 'claude-hooks' to 'carabiner'
- Update schema URL to https://carabiner.outfitter.dev/schema.json
- Update all documentation references to use Carabiner branding
- Update VS Code settings from carabiner.hooks.* pattern
- Keep monorepo root as 'carabiner-monorepo' for clarity

This completes the migration to the @carabiner npm scope, establishing
Carabiner as its own distinct product for building type-safe hooks.