### PR TITLE
fix: restore biome-ignore directives for P1 lint issues

### DIFF
--- a/packages/hooks-cli/src/commands/init.ts
+++ b/packages/hooks-cli/src/commands/init.ts
@@ -9,174 +9,174 @@ import { DEFAULT_CONFIG } from "@carabiner/hooks-config";
 import { BaseCommand, type CliConfig } from "../types";
 
 export class InitCommand extends BaseCommand {
-	name = "init";
-	description = "Initialize Claude Code hooks in your project";
-	usage = "init [options]";
-	options = {
-		"--typescript, -t": "Generate TypeScript hooks (default)",
-		"--javascript, -j": "Generate JavaScript hooks",
-		"--template": "Template to use (basic, advanced, security)",
-		"--force, -f": "Overwrite existing files",
-		"--help, -h": "Show help",
-	};
+  name = "init";
+  description = "Initialize Claude Code hooks in your project";
+  usage = "init [options]";
+  options = {
+    "--typescript, -t": "Generate TypeScript hooks (default)",
+    "--javascript, -j": "Generate JavaScript hooks",
+    "--template": "Template to use (basic, advanced, security)",
+    "--force, -f": "Overwrite existing files",
+    "--help, -h": "Show help",
+  };
 
-	async execute(args: string[], config: CliConfig): Promise<void> {
-		const { values } = this.parseArgs(args, {
-			help: { type: "boolean", short: "h" },
-			typescript: { type: "boolean", short: "t", default: true },
-			javascript: { type: "boolean", short: "j" },
-			template: { type: "string", default: "basic" },
-			force: { type: "boolean", short: "f" },
-		});
+  async execute(args: string[], config: CliConfig): Promise<void> {
+    const { values } = this.parseArgs(args, {
+      help: { type: "boolean", short: "h" },
+      typescript: { type: "boolean", short: "t", default: true },
+      javascript: { type: "boolean", short: "j" },
+      template: { type: "string", default: "basic" },
+      force: { type: "boolean", short: "f" },
+    });
 
-		if (values.help) {
-			this.showHelp();
-			return;
-		}
+    if (values.help) {
+      this.showHelp();
+      return;
+    }
 
-		const useTypeScript = !this.getBooleanValue(values.javascript);
-		const template = this.getStringValue(values.template, "basic");
-		const force = this.getBooleanValue(values.force);
+    const useTypeScript = !this.getBooleanValue(values.javascript);
+    const template = this.getStringValue(values.template, "basic");
+    const force = this.getBooleanValue(values.force);
 
-		try {
-			await this.createDirectoryStructure(config.workspacePath, force);
-			await this.createConfiguration(config.workspacePath, force);
-			await this.createHookFiles(
-				config.workspacePath,
-				useTypeScript,
-				template,
-				force,
-			);
-			await this.createPackageScripts(config.workspacePath, force);
-			await this.createGitignore(config.workspacePath, force);
-		} catch (error) {
-			throw new Error(
-				`Initialization failed: ${error instanceof Error ? error.message : error}`,
-			);
-		}
-	}
+    try {
+      await this.createDirectoryStructure(config.workspacePath, force);
+      await this.createConfiguration(config.workspacePath, force);
+      await this.createHookFiles(
+        config.workspacePath,
+        useTypeScript,
+        template,
+        force
+      );
+      await this.createPackageScripts(config.workspacePath, force);
+      await this.createGitignore(config.workspacePath, force);
+    } catch (error) {
+      throw new Error(
+        `Initialization failed: ${error instanceof Error ? error.message : error}`
+      );
+    }
+  }
 
-	/**
-	 * Create directory structure
-	 */
-	private async createDirectoryStructure(
-		workspacePath: string,
-		_force: boolean,
-	): Promise<void> {
-		const directories = [".claude", "hooks", "hooks/lib", "hooks/test"];
+  /**
+   * Create directory structure
+   */
+  private async createDirectoryStructure(
+    workspacePath: string,
+    _force: boolean
+  ): Promise<void> {
+    const directories = [".claude", "hooks", "hooks/lib", "hooks/test"];
 
-		// Create directories in parallel
-		const dirCreationPromises = directories.map(async (dir) => {
-			const dirPath = join(workspacePath, dir);
-			if (!existsSync(dirPath)) {
-				await mkdir(dirPath, { recursive: true });
-			}
-		});
+    // Create directories in parallel
+    const dirCreationPromises = directories.map(async (dir) => {
+      const dirPath = join(workspacePath, dir);
+      if (!existsSync(dirPath)) {
+        await mkdir(dirPath, { recursive: true });
+      }
+    });
 
-		await Promise.all(dirCreationPromises);
-	}
+    await Promise.all(dirCreationPromises);
+  }
 
-	/**
-	 * Create configuration files
-	 */
-	private async createConfiguration(
-		workspacePath: string,
-		force: boolean,
-	): Promise<void> {
-		// Create hooks configuration
-		const configPath = join(workspacePath, ".claude", "hooks.json");
-		if (!existsSync(configPath) || force) {
-			await writeFile(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2));
-		}
+  /**
+   * Create configuration files
+   */
+  private async createConfiguration(
+    workspacePath: string,
+    force: boolean
+  ): Promise<void> {
+    // Create hooks configuration
+    const configPath = join(workspacePath, ".claude", "hooks.json");
+    if (!existsSync(configPath) || force) {
+      await writeFile(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2));
+    }
 
-		// Create Claude settings
-		const settingsPath = join(workspacePath, ".claude", "settings.json");
-		if (!existsSync(settingsPath) || force) {
-			const settings = {
-				hooks: {
-					PreToolUse: {
-						Bash: {
-							command: "bun run hooks/pre-tool-use.ts",
-							timeout: 5000,
-						},
-						Write: {
-							command: "bun run hooks/pre-tool-use.ts",
-							timeout: 3000,
-						},
-						Edit: {
-							command: "bun run hooks/pre-tool-use.ts",
-							timeout: 3000,
-						},
-					},
-					PostToolUse: {
-						Write: {
-							command: "bun run hooks/post-tool-use.ts",
-							timeout: 30_000,
-						},
-						Edit: {
-							command: "bun run hooks/post-tool-use.ts",
-							timeout: 30_000,
-						},
-					},
-					SessionStart: {
-						command: "bun run hooks/session-start.ts",
-						timeout: 10_000,
-					},
-				},
-			};
+    // Create Claude settings
+    const settingsPath = join(workspacePath, ".claude", "settings.json");
+    if (!existsSync(settingsPath) || force) {
+      const settings = {
+        hooks: {
+          PreToolUse: {
+            Bash: {
+              command: "bun run hooks/pre-tool-use.ts",
+              timeout: 5000,
+            },
+            Write: {
+              command: "bun run hooks/pre-tool-use.ts",
+              timeout: 3000,
+            },
+            Edit: {
+              command: "bun run hooks/pre-tool-use.ts",
+              timeout: 3000,
+            },
+          },
+          PostToolUse: {
+            Write: {
+              command: "bun run hooks/post-tool-use.ts",
+              timeout: 30_000,
+            },
+            Edit: {
+              command: "bun run hooks/post-tool-use.ts",
+              timeout: 30_000,
+            },
+          },
+          SessionStart: {
+            command: "bun run hooks/session-start.ts",
+            timeout: 10_000,
+          },
+        },
+      };
 
-			await writeFile(settingsPath, JSON.stringify(settings, null, 2));
-		}
-	}
+      await writeFile(settingsPath, JSON.stringify(settings, null, 2));
+    }
+  }
 
-	/**
-	 * Create hook files
-	 */
-	private async createHookFiles(
-		workspacePath: string,
-		useTypeScript: boolean,
-		template: string,
-		force: boolean,
-	): Promise<void> {
-		const extension = useTypeScript ? "ts" : "js";
-		const hooksDir = join(workspacePath, "hooks");
+  /**
+   * Create hook files
+   */
+  private async createHookFiles(
+    workspacePath: string,
+    useTypeScript: boolean,
+    template: string,
+    force: boolean
+  ): Promise<void> {
+    const extension = useTypeScript ? "ts" : "js";
+    const hooksDir = join(workspacePath, "hooks");
 
-		// Create lib files
-		await this.createLibFiles(hooksDir, extension, force);
+    // Create lib files
+    await this.createLibFiles(hooksDir, extension, force);
 
-		// Create hook files based on template
-		switch (template) {
-			case "basic":
-				await this.createBasicHooks(hooksDir, extension, force);
-				break;
-			case "advanced":
-				await this.createAdvancedHooks(hooksDir, extension, force);
-				break;
-			case "security":
-				await this.createSecurityHooks(hooksDir, extension, force);
-				break;
-			default:
-				throw new Error(`Unknown template: ${template}`);
-		}
+    // Create hook files based on template
+    switch (template) {
+      case "basic":
+        await this.createBasicHooks(hooksDir, extension, force);
+        break;
+      case "advanced":
+        await this.createAdvancedHooks(hooksDir, extension, force);
+        break;
+      case "security":
+        await this.createSecurityHooks(hooksDir, extension, force);
+        break;
+      default:
+        throw new Error(`Unknown template: ${template}`);
+    }
 
-		// Create test files
-		await this.createTestFiles(hooksDir, extension, force);
-	}
+    // Create test files
+    await this.createTestFiles(hooksDir, extension, force);
+  }
 
-	/**
-	 * Create library files
-	 */
-	private async createLibFiles(
-		hooksDir: string,
-		extension: string,
-		force: boolean,
-	): Promise<void> {
-		const libDir = join(hooksDir, "lib");
+  /**
+   * Create library files
+   */
+  private async createLibFiles(
+    hooksDir: string,
+    extension: string,
+    force: boolean
+  ): Promise<void> {
+    const libDir = join(hooksDir, "lib");
 
-		// Create types file
-		const typesContent = (useTypeScript: boolean) =>
-			useTypeScript
-				? `
+    // Create types file
+    const typesContent = (useTypeScript: boolean) =>
+      useTypeScript
+        ? `
 export * from '@carabiner/hooks-core';
 export * from '@carabiner/hooks-validators';
 export * from '@carabiner/hooks-config';
@@ -188,22 +188,22 @@ export interface CustomHookData {
   metadata?: Record<string, unknown>;
 }
 `
-				: `
+        : `
 // Custom types and utilities for your hooks
 module.exports = {
   // Add your custom utilities here
 };
 `;
 
-		const typesPath = join(libDir, `types.${extension}`);
-		if (!existsSync(typesPath) || force) {
-			await writeFile(typesPath, typesContent(extension === "ts"));
-		}
+    const typesPath = join(libDir, `types.${extension}`);
+    if (!existsSync(typesPath) || force) {
+      await writeFile(typesPath, typesContent(extension === "ts"));
+    }
 
-		// Create utils file
-		const utilsContent =
-			extension === "ts"
-				? `
+    // Create utils file
+    const utilsContent =
+      extension === "ts"
+        ? `
 import type { HookContext, HookResult } from './types.ts';
 
 /**
@@ -240,7 +240,7 @@ export const HookUtils = {
   }
 };
 `
-				: `
+        : `
 /**
  * Common utilities for hooks
  */
@@ -278,61 +278,61 @@ const HookUtils = {
 module.exports = { HookUtils };
 `;
 
-		const utilsPath = join(libDir, `utils.${extension}`);
-		if (!existsSync(utilsPath) || force) {
-			await writeFile(utilsPath, utilsContent);
-		}
-	}
+    const utilsPath = join(libDir, `utils.${extension}`);
+    if (!existsSync(utilsPath) || force) {
+      await writeFile(utilsPath, utilsContent);
+    }
+  }
 
-	/**
-	 * Create basic hook files
-	 */
-	private async createBasicHooks(
-		hooksDir: string,
-		extension: string,
-		force: boolean,
-	): Promise<void> {
-		const hooks = [
-			{
-				name: "pre-tool-use",
-				content: this.getBasicPreToolUseHook(extension === "ts"),
-			},
-			{
-				name: "post-tool-use",
-				content: this.getBasicPostToolUseHook(extension === "ts"),
-			},
-			{
-				name: "session-start",
-				content: this.getBasicSessionStartHook(extension === "ts"),
-			},
-		];
+  /**
+   * Create basic hook files
+   */
+  private async createBasicHooks(
+    hooksDir: string,
+    extension: string,
+    force: boolean
+  ): Promise<void> {
+    const hooks = [
+      {
+        name: "pre-tool-use",
+        content: this.getBasicPreToolUseHook(extension === "ts"),
+      },
+      {
+        name: "post-tool-use",
+        content: this.getBasicPostToolUseHook(extension === "ts"),
+      },
+      {
+        name: "session-start",
+        content: this.getBasicSessionStartHook(extension === "ts"),
+      },
+    ];
 
-		// Write hook files in parallel
-		const hookWritePromises = hooks.map(async (hook) => {
-			const filePath = join(hooksDir, `${hook.name}.${extension}`);
-			if (!existsSync(filePath) || force) {
-				await writeFile(filePath, hook.content);
-			}
-		});
+    // Write hook files in parallel
+    const hookWritePromises = hooks.map(async (hook) => {
+      const filePath = join(hooksDir, `${hook.name}.${extension}`);
+      if (!existsSync(filePath) || force) {
+        await writeFile(filePath, hook.content);
+      }
+    });
 
-		await Promise.all(hookWritePromises);
-	}
+    await Promise.all(hookWritePromises);
+  }
 
-	/**
-	 * Create advanced hook files
-	 */
-	private async createAdvancedHooks(
-		hooksDir: string,
-		extension: string,
-		force: boolean,
-	): Promise<void> {
-		// Implementation for advanced hooks with more features
-		await this.createBasicHooks(hooksDir, extension, force);
+  /**
+   * Create advanced hook files
+   */
+  private async createAdvancedHooks(
+    hooksDir: string,
+    extension: string,
+    force: boolean
+  ): Promise<void> {
+    // Implementation for advanced hooks with more features
+    await this.createBasicHooks(hooksDir, extension, force);
 
-		// Add advanced features file
-		const advancedContent =
-			extension === "ts"
-				? `
+    // Add advanced features file
+    const advancedContent =
+      extension === "ts"
+        ? `
 import { HookBuilder, middleware } from '@carabiner/hooks-core';
 import { SecurityValidators } from '@carabiner/hooks-validators';
 
@@ -349,30 +349,30 @@ export const advancedPreToolUse = HookBuilder
   })
   .build();
 `
-				: `
+        : `
 // Advanced hook composition example
 // Requires @outfitter/hooks-core and @outfitter/hooks-validators
 `;
 
-		const advancedPath = join(hooksDir, `advanced.${extension}`);
-		if (!existsSync(advancedPath) || force) {
-			await writeFile(advancedPath, advancedContent);
-		}
-	}
+    const advancedPath = join(hooksDir, `advanced.${extension}`);
+    if (!existsSync(advancedPath) || force) {
+      await writeFile(advancedPath, advancedContent);
+    }
+  }
 
-	/**
-	 * Create security-focused hook files
-	 */
-	private async createSecurityHooks(
-		hooksDir: string,
-		extension: string,
-		force: boolean,
-	): Promise<void> {
-		await this.createBasicHooks(hooksDir, extension, force);
+  /**
+   * Create security-focused hook files
+   */
+  private async createSecurityHooks(
+    hooksDir: string,
+    extension: string,
+    force: boolean
+  ): Promise<void> {
+    await this.createBasicHooks(hooksDir, extension, force);
 
-		const securityContent =
-			extension === "ts"
-				? `
+    const securityContent =
+      extension === "ts"
+        ? `
 import { SecurityValidators, validateHookSecurity } from '@carabiner/hooks-validators';
 import type { HookContext, HookResult } from '@carabiner/hooks-core';
 
@@ -404,30 +404,30 @@ export async function securityHookHandler(context: HookContext): Promise<HookRes
   }
 }
 `
-				: `
+        : `
 // Security-focused hook handlers
 // Requires @outfitter/hooks-validators
 `;
 
-		const securityPath = join(hooksDir, `security.${extension}`);
-		if (!existsSync(securityPath) || force) {
-			await writeFile(securityPath, securityContent);
-		}
-	}
+    const securityPath = join(hooksDir, `security.${extension}`);
+    if (!existsSync(securityPath) || force) {
+      await writeFile(securityPath, securityContent);
+    }
+  }
 
-	/**
-	 * Create test files
-	 */
-	private async createTestFiles(
-		hooksDir: string,
-		extension: string,
-		force: boolean,
-	): Promise<void> {
-		const testDir = join(hooksDir, "test");
+  /**
+   * Create test files
+   */
+  private async createTestFiles(
+    hooksDir: string,
+    extension: string,
+    force: boolean
+  ): Promise<void> {
+    const testDir = join(hooksDir, "test");
 
-		const testContent =
-			extension === "ts"
-				? `
+    const testContent =
+      extension === "ts"
+        ? `
 import { test, expect } from 'bun:test';
 import { createMockContextFor, TestUtils } from '@carabiner/hooks-testing';
 import { handlePreToolUse } from '../pre-tool-use.ts';
@@ -448,87 +448,88 @@ test('PreToolUse hook should block dangerous commands', async () => {
   expect(result.block).toBe(true);
 });
 `
-				: `
+        : `
 // Test file for hooks
 // Requires @outfitter/hooks-testing and bun:test
 const { test, expect } = require('bun:test');
 // Add your tests here
 `;
 
-		const testPath = join(testDir, `hooks.test.${extension}`);
-		if (!existsSync(testPath) || force) {
-			await writeFile(testPath, testContent);
-		}
-	}
+    const testPath = join(testDir, `hooks.test.${extension}`);
+    if (!existsSync(testPath) || force) {
+      await writeFile(testPath, testContent);
+    }
+  }
 
-	/**
-	 * Create or update package.json scripts
-	 */
-	private async createPackageScripts(
-		workspacePath: string,
-		force: boolean,
-	): Promise<void> {
-		const packagePath = join(workspacePath, "package.json");
+  /**
+   * Create or update package.json scripts
+   */
+  private async createPackageScripts(
+    workspacePath: string,
+    force: boolean
+  ): Promise<void> {
+    const packagePath = join(workspacePath, "package.json");
 
-		if (existsSync(packagePath)) {
-			const packageJson = JSON.parse(
-				await readFileContent(packagePath, "utf-8"),
-			);
+    if (existsSync(packagePath)) {
+      const packageJson = JSON.parse(
+        await readFileContent(packagePath, "utf-8")
+      );
 
-			const scripts = packageJson.scripts || {};
-			const newScripts = {
-				"hooks:test": "bun test hooks/test/",
-				"hooks:validate": "carabiner validate",
-				"hooks:debug": "bun run hooks/debug.ts",
-			};
+      const scripts = packageJson.scripts || {};
+      const newScripts = {
+        "hooks:test": "bun test hooks/test/",
+        "hooks:validate": "carabiner validate",
+        "hooks:debug": "bun run hooks/debug.ts",
+      };
 
-			let hasChanges = false;
-			for (const [key, value] of Object.entries(newScripts)) {
-				if (!scripts[key] || force) {
-					scripts[key] = value;
-					hasChanges = true;
-				}
-			}
+      let hasChanges = false;
+      for (const [key, value] of Object.entries(newScripts)) {
+        if (!scripts[key] || force) {
+          scripts[key] = value;
+          hasChanges = true;
+        }
+      }
 
-			if (hasChanges) {
-				packageJson.scripts = scripts;
-				await writeFile(packagePath, JSON.stringify(packageJson, null, 2));
-			}
-		}
-	}
+      // biome-ignore lint/nursery/noUnnecessaryConditions: hasChanges is mutated in the loop above
+      if (hasChanges) {
+        packageJson.scripts = scripts;
+        await writeFile(packagePath, JSON.stringify(packageJson, null, 2));
+      }
+    }
+  }
 
-	/**
-	 * Create or update .gitignore
-	 */
-	private async createGitignore(
-		workspacePath: string,
-		force: boolean,
-	): Promise<void> {
-		const gitignorePath = join(workspacePath, ".gitignore");
-		const hookEntries = [
-			"",
-			"# Claude Code Hooks",
-			".claude/logs/",
-			"hooks/temp/",
-			"hooks/*.log",
-		].join("\n");
+  /**
+   * Create or update .gitignore
+   */
+  private async createGitignore(
+    workspacePath: string,
+    force: boolean
+  ): Promise<void> {
+    const gitignorePath = join(workspacePath, ".gitignore");
+    const hookEntries = [
+      "",
+      "# Claude Code Hooks",
+      ".claude/logs/",
+      "hooks/temp/",
+      "hooks/*.log",
+    ].join("\n");
 
-		if (existsSync(gitignorePath)) {
-			const content = await readFileContent(gitignorePath, "utf-8");
-			if (!content.includes("# Claude Code Hooks") || force) {
-				await writeFile(gitignorePath, `${content}\n${hookEntries}`);
-			}
-		} else {
-			await writeFile(gitignorePath, hookEntries);
-		}
-	}
+    if (existsSync(gitignorePath)) {
+      const content = await readFileContent(gitignorePath, "utf-8");
+      if (!content.includes("# Claude Code Hooks") || force) {
+        await writeFile(gitignorePath, `${content}\n${hookEntries}`);
+      }
+    } else {
+      await writeFile(gitignorePath, hookEntries);
+    }
+  }
 
-	/**
-	 * Get basic PreToolUse hook template
-	 */
-	private getBasicPreToolUseHook(isTypeScript: boolean): string {
-		if (isTypeScript) {
-			return `#!/usr/bin/env bun
+  /**
+   * Get basic PreToolUse hook template
+   */
+  private getBasicPreToolUseHook(isTypeScript: boolean): string {
+    if (isTypeScript) {
+      return `#!/usr/bin/env bun
 
 import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
 import { validateHookSecurity } from '@carabiner/hooks-validators';
@@ -568,8 +569,8 @@ if (import.meta.main) {
 
 export { handlePreToolUse };
 `;
-		}
-		return `#!/usr/bin/env bun
+    }
+    return `#!/usr/bin/env bun
 
 const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
 const { validateHookSecurity } = require('@carabiner/hooks-validators');
@@ -608,14 +609,14 @@ if (require.main === module) {
 
 module.exports = { handlePreToolUse };
 `;
-	}
+  }
 
-	/**
-	 * Get basic PostToolUse hook template
-	 */
-	private getBasicPostToolUseHook(isTypeScript: boolean): string {
-		if (isTypeScript) {
-			return `#!/usr/bin/env bun
+  /**
+   * Get basic PostToolUse hook template
+   */
+  private getBasicPostToolUseHook(isTypeScript: boolean): string {
+    if (isTypeScript) {
+      return `#!/usr/bin/env bun
 
 import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
 import type { HookResult } from '@carabiner/hooks-core';
@@ -647,8 +648,8 @@ if (import.meta.main) {
 
 export { handlePostToolUse };
 `;
-		}
-		return `#!/usr/bin/env bun
+    }
+    return `#!/usr/bin/env bun
 
 const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
 
@@ -679,14 +680,14 @@ if (require.main === module) {
 
 module.exports = { handlePostToolUse };
 `;
-	}
+  }
 
-	/**
-	 * Get basic SessionStart hook template
-	 */
-	private getBasicSessionStartHook(isTypeScript: boolean): string {
-		if (isTypeScript) {
-			return `#!/usr/bin/env bun
+  /**
+   * Get basic SessionStart hook template
+   */
+  private getBasicSessionStartHook(isTypeScript: boolean): string {
+    if (isTypeScript) {
+      return `#!/usr/bin/env bun
 
 import { createHookContext, exitWithResult, HookResults } from '@carabiner/hooks-core';
 import type { HookResult } from '@carabiner/hooks-core';
@@ -740,8 +741,8 @@ if (import.meta.main) {
 
 export { handleSessionStart };
 `;
-		}
-		return `#!/usr/bin/env bun
+    }
+    return `#!/usr/bin/env bun
 
 const { createHookContext, exitWithResult, HookResults } = require('@carabiner/hooks-core');
 const { existsSync, readFileSync } = require('node:fs');
@@ -794,14 +795,14 @@ if (require.main === module) {
 
 module.exports = { handleSessionStart };
 `;
-	}
+  }
 }
 
 // Helper function to read files
 async function readFileContent(
-	path: string,
-	encoding: string,
+  path: string,
+  encoding: string
 ): Promise<string> {
-	const { readFile: fsReadFile } = await import("node:fs/promises");
-	return fsReadFile(path, encoding as BufferEncoding);
+  const { readFile: fsReadFile } = await import("node:fs/promises");
+  return fsReadFile(path, encoding as BufferEncoding);
 }

--- a/packages/hooks-cli/src/commands/validate.ts
+++ b/packages/hooks-cli/src/commands/validate.ts
@@ -6,8 +6,8 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
-	type ExtendedHookConfiguration,
-	loadConfig,
+  type ExtendedHookConfiguration,
+  loadConfig,
 } from "@carabiner/hooks-config";
 import type { ToolHookConfig } from "@carabiner/hooks-core";
 import { BaseCommand, type CliConfig } from "../types";
@@ -17,406 +17,407 @@ const HOOK_FILE_REGEX = /\.(ts|js)$/;
 const BUN_RUN_REGEX = /bun\s+run\s+(?:-S\s+)?(?:"([^"]+)"|'([^']+)'|(\S+))/;
 
 export class ValidateCommand extends BaseCommand {
-	name = "validate";
-	description = "Validate hook configuration and files";
-	usage = "validate [options]";
-	options = {
-		"--config, -c": "Validate configuration only",
-		"--hooks, -k": "Validate hook files only",
-		"--fix": "Automatically fix issues where possible",
-		"--verbose, -v": "Show detailed validation output",
-		"--help, -h": "Show help",
-	};
+  name = "validate";
+  description = "Validate hook configuration and files";
+  usage = "validate [options]";
+  options = {
+    "--config, -c": "Validate configuration only",
+    "--hooks, -k": "Validate hook files only",
+    "--fix": "Automatically fix issues where possible",
+    "--verbose, -v": "Show detailed validation output",
+    "--help, -h": "Show help",
+  };
 
-	async execute(args: string[], config: CliConfig): Promise<void> {
-		const { values } = this.parseArgs(args, {
-			help: { type: "boolean", short: "h" },
-			config: { type: "boolean", short: "c" },
-			hooks: { type: "boolean", short: "k" },
-			fix: { type: "boolean" },
-			verbose: { type: "boolean", short: "v" },
-		});
+  async execute(args: string[], config: CliConfig): Promise<void> {
+    const { values } = this.parseArgs(args, {
+      help: { type: "boolean", short: "h" },
+      config: { type: "boolean", short: "c" },
+      hooks: { type: "boolean", short: "k" },
+      fix: { type: "boolean" },
+      verbose: { type: "boolean", short: "v" },
+    });
 
-		if (values.help) {
-			this.showHelp();
-			return;
-		}
+    if (values.help) {
+      this.showHelp();
+      return;
+    }
 
-		const validateConfig = !this.getBooleanValue(values.hooks);
-		const validateHooks = !this.getBooleanValue(values.config);
-		const autoFix = this.getBooleanValue(values.fix);
-		const verbose = this.getBooleanValue(values.verbose) || config.verbose;
+    const validateConfig = !this.getBooleanValue(values.hooks);
+    const validateHooks = !this.getBooleanValue(values.config);
+    const autoFix = this.getBooleanValue(values.fix);
+    const verbose = this.getBooleanValue(values.verbose) || config.verbose;
 
-		let hasErrors = false;
+    let hasErrors = false;
 
-		try {
-			if (validateConfig) {
-				const configErrors = await this.validateConfiguration(
-					config.workspacePath,
-					verbose,
-					autoFix,
-				);
-				if (configErrors > 0) {
-					hasErrors = true;
-				}
-			}
+    try {
+      if (validateConfig) {
+        const configErrors = await this.validateConfiguration(
+          config.workspacePath,
+          verbose,
+          autoFix
+        );
+        if (configErrors > 0) {
+          hasErrors = true;
+        }
+      }
 
-			if (validateHooks) {
-				const hookErrors = await this.validateHookFiles(
-					config.workspacePath,
-					verbose,
-					autoFix,
-				);
-				if (hookErrors > 0) {
-					hasErrors = true;
-				}
-			}
+      if (validateHooks) {
+        const hookErrors = await this.validateHookFiles(
+          config.workspacePath,
+          verbose,
+          autoFix
+        );
+        if (hookErrors > 0) {
+          hasErrors = true;
+        }
+      }
 
-			if (hasErrors) {
-				if (!autoFix) {
-					process.stderr.write(
-						"Validation found issues. Re-run with --fix to attempt automatic remediation.\n",
-					);
-				}
-				process.exit(1);
-			} else if (verbose) {
-				process.stdout.write("Validation passed.\n");
-			}
-		} catch (error) {
-			const message = `Validation failed: ${error instanceof Error ? error.message : String(error)}`;
-			throw new Error(message, { cause: error as unknown });
-		}
-	}
+      // biome-ignore lint/nursery/noUnnecessaryConditions: hasErrors is mutated based on validation results
+      if (hasErrors) {
+        if (!autoFix) {
+          process.stderr.write(
+            "Validation found issues. Re-run with --fix to attempt automatic remediation.\n"
+          );
+        }
+        process.exit(1);
+      } else if (verbose) {
+        process.stdout.write("Validation passed.\n");
+      }
+    } catch (error) {
+      const message = `Validation failed: ${error instanceof Error ? error.message : String(error)}`;
+      throw new Error(message, { cause: error as unknown });
+    }
+  }
 
-	/**
-	 * Validate configuration files
-	 */
-	private async validateConfiguration(
-		workspacePath: string,
-		verbose: boolean,
-		autoFix: boolean,
-	): Promise<number> {
-		let errors = 0;
+  /**
+   * Validate configuration files
+   */
+  private async validateConfiguration(
+    workspacePath: string,
+    verbose: boolean,
+    autoFix: boolean
+  ): Promise<number> {
+    let errors = 0;
 
-		try {
-			// Check if configuration exists
-			const configPaths = [
-				".claude/hooks.json",
-				".claude/hooks.config.ts",
-				".claude/hooks.config.js",
-			];
+    try {
+      // Check if configuration exists
+      const configPaths = [
+        ".claude/hooks.json",
+        ".claude/hooks.config.ts",
+        ".claude/hooks.config.js",
+      ];
 
-			let configExists = false;
+      let configExists = false;
 
-			for (const path of configPaths) {
-				const fullPath = join(workspacePath, path);
-				if (existsSync(fullPath)) {
-					configExists = true;
-					// Config path found: path
-					break;
-				}
-			}
+      for (const path of configPaths) {
+        const fullPath = join(workspacePath, path);
+        if (existsSync(fullPath)) {
+          configExists = true;
+          // Config path found: path
+          break;
+        }
+      }
 
-			if (!configExists) {
-				return ++errors;
-			}
+      if (!configExists) {
+        return ++errors;
+      }
 
-			if (verbose) {
-				// TODO: Log configuration found
-			}
+      if (verbose) {
+        // TODO: Log configuration found
+      }
 
-			// Load and validate configuration
-			const config = await loadConfig(workspacePath, { validate: true });
+      // Load and validate configuration
+      const config = await loadConfig(workspacePath, { validate: true });
 
-			if (verbose) {
-				// TODO: Log configuration loaded successfully
-			}
+      if (verbose) {
+        // TODO: Log configuration loaded successfully
+      }
 
-			// Validate Claude settings
-			const settingsPath = join(workspacePath, ".claude/settings.json");
-			if (existsSync(settingsPath)) {
-				const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+      // Validate Claude settings
+      const settingsPath = join(workspacePath, ".claude/settings.json");
+      if (existsSync(settingsPath)) {
+        const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
 
-				if (!settings.hooks) {
-					if (autoFix) {
-						// TODO: Implement auto-fix for missing hooks section
-					} else {
-						// TODO: Log error about missing hooks section
-					}
-					errors++;
-				} else if (verbose) {
-					// TODO: Log Claude settings validation passed
-				}
-			} else {
-				errors++;
-			}
+        if (!settings.hooks) {
+          if (autoFix) {
+            // TODO: Implement auto-fix for missing hooks section
+          } else {
+            // TODO: Log error about missing hooks section
+          }
+          errors++;
+        } else if (verbose) {
+          // TODO: Log Claude settings validation passed
+        }
+      } else {
+        errors++;
+      }
 
-			// Validate hook commands exist
-			errors += this.validateHookCommands(
-				config,
-				workspacePath,
-				verbose,
-				autoFix,
-			);
-		} catch (_error) {
-			errors++;
-		}
+      // Validate hook commands exist
+      errors += this.validateHookCommands(
+        config,
+        workspacePath,
+        verbose,
+        autoFix
+      );
+    } catch (_error) {
+      errors++;
+    }
 
-		return errors;
-	}
+    return errors;
+  }
 
-	/**
-	 * Validate hook commands exist
-	 */
-	private validateHookCommands(
-		config: ExtendedHookConfiguration,
-		workspacePath: string,
-		verbose: boolean,
-		_autoFix: boolean,
-	): number {
-		let errors = 0;
+  /**
+   * Validate hook commands exist
+   */
+  private validateHookCommands(
+    config: ExtendedHookConfiguration,
+    workspacePath: string,
+    verbose: boolean,
+    _autoFix: boolean
+  ): number {
+    let errors = 0;
 
-		// Check each configured hook
-		for (const [event, eventConfig] of Object.entries(config)) {
-			if (
-				event.startsWith("$") ||
-				["templates", "variables", "environments"].includes(event)
-			) {
-				continue;
-			}
+    // Check each configured hook
+    for (const [event, eventConfig] of Object.entries(config)) {
+      if (
+        event.startsWith("$") ||
+        ["templates", "variables", "environments"].includes(event)
+      ) {
+        continue;
+      }
 
-			if (eventConfig && typeof eventConfig === "object") {
-				if ("command" in eventConfig) {
-					// Single hook config
-					errors += this.validateCommand(eventConfig as ToolHookConfig, {
-						event,
-						tool: "",
-						workspacePath,
-						verbose,
-						autoFix: _autoFix,
-					});
-				} else {
-					// Tool-specific configs
-					for (const [tool, toolConfig] of Object.entries(eventConfig)) {
-						if (
-							toolConfig &&
-							typeof toolConfig === "object" &&
-							"command" in toolConfig
-						) {
-							errors += this.validateCommand(toolConfig as ToolHookConfig, {
-								event,
-								tool,
-								workspacePath,
-								verbose,
-								autoFix: _autoFix,
-							});
-						}
-					}
-				}
-			}
-		}
+      if (eventConfig && typeof eventConfig === "object") {
+        if ("command" in eventConfig) {
+          // Single hook config
+          errors += this.validateCommand(eventConfig as ToolHookConfig, {
+            event,
+            tool: "",
+            workspacePath,
+            verbose,
+            autoFix: _autoFix,
+          });
+        } else {
+          // Tool-specific configs
+          for (const [tool, toolConfig] of Object.entries(eventConfig)) {
+            if (
+              toolConfig &&
+              typeof toolConfig === "object" &&
+              "command" in toolConfig
+            ) {
+              errors += this.validateCommand(toolConfig as ToolHookConfig, {
+                event,
+                tool,
+                workspacePath,
+                verbose,
+                autoFix: _autoFix,
+              });
+            }
+          }
+        }
+      }
+    }
 
-		return errors;
-	}
+    return errors;
+  }
 
-	/**
-	 * Validate a specific hook command
-	 */
-	private validateCommand(
-		hookConfig: ToolHookConfig,
-		context: {
-			event: string;
-			tool: string;
-			workspacePath: string;
-			verbose: boolean;
-			autoFix: boolean;
-		},
-	): number {
-		// Hook name for context: tool ? `${event}:${tool}` : event
+  /**
+   * Validate a specific hook command
+   */
+  private validateCommand(
+    hookConfig: ToolHookConfig,
+    context: {
+      event: string;
+      tool: string;
+      workspacePath: string;
+      verbose: boolean;
+      autoFix: boolean;
+    }
+  ): number {
+    // Hook name for context: tool ? `${event}:${tool}` : event
 
-		if (hookConfig.enabled === false) {
-			if (context.verbose) {
-				// TODO: Log hook is disabled, skipping validation
-			}
-			return 0;
-		}
+    if (hookConfig.enabled === false) {
+      if (context.verbose) {
+        // TODO: Log hook is disabled, skipping validation
+      }
+      return 0;
+    }
 
-		// Extract file path from command
-		const command = hookConfig.command;
-		const match = command.match(BUN_RUN_REGEX);
-		const scriptPath = match?.[1] ?? match?.[2] ?? match?.[3];
-		if (scriptPath) {
-			const fullPath = join(context.workspacePath, scriptPath);
+    // Extract file path from command
+    const command = hookConfig.command;
+    const match = command.match(BUN_RUN_REGEX);
+    const scriptPath = match?.[1] ?? match?.[2] ?? match?.[3];
+    if (scriptPath) {
+      const fullPath = join(context.workspacePath, scriptPath);
 
-			if (!existsSync(fullPath)) {
-				if (context.autoFix) {
-					// TODO: Implement auto-generation of missing hook files
-				} else {
-					// TODO: Log hook file not found
-				}
-				return 1;
-			}
-			if (context.verbose) {
-				// TODO: Log hook file exists
-			}
-		} else if (context.verbose) {
-			// TODO: Log non-standard command format
-		}
+      if (!existsSync(fullPath)) {
+        if (context.autoFix) {
+          // TODO: Implement auto-generation of missing hook files
+        } else {
+          // TODO: Log hook file not found
+        }
+        return 1;
+      }
+      if (context.verbose) {
+        // TODO: Log hook file exists
+      }
+    } else if (context.verbose) {
+      // TODO: Log non-standard command format
+    }
 
-		return 0;
-	}
+    return 0;
+  }
 
-	/**
-	 * Validate hook files
-	 */
-	private async validateHookFiles(
-		workspacePath: string,
-		verbose: boolean,
-		autoFix: boolean,
-	): Promise<number> {
-		let errors = 0;
+  /**
+   * Validate hook files
+   */
+  private async validateHookFiles(
+    workspacePath: string,
+    verbose: boolean,
+    autoFix: boolean
+  ): Promise<number> {
+    let errors = 0;
 
-		const hooksDir = join(workspacePath, "hooks");
+    const hooksDir = join(workspacePath, "hooks");
 
-		if (!existsSync(hooksDir)) {
-			return ++errors;
-		}
+    if (!existsSync(hooksDir)) {
+      return ++errors;
+    }
 
-		if (verbose) {
-			// TODO: Log validating hook files
-		}
+    if (verbose) {
+      // TODO: Log validating hook files
+    }
 
-		// Find all hook files
-		const hookFiles = await this.findHookFiles(hooksDir);
+    // Find all hook files
+    const hookFiles = await this.findHookFiles(hooksDir);
 
-		if (hookFiles.length === 0) {
-			// TODO: Log no hook files found
-		} else if (verbose) {
-			// TODO: Log found X hook files to validate
-		}
+    if (hookFiles.length === 0) {
+      // TODO: Log no hook files found
+    } else if (verbose) {
+      // TODO: Log found X hook files to validate
+    }
 
-		// Validate each hook file
-		for (const filePath of hookFiles) {
-			errors += await this.validateHookFile(
-				filePath,
-				workspacePath,
-				verbose,
-				autoFix,
-			);
-		}
+    // Validate each hook file
+    for (const filePath of hookFiles) {
+      errors += await this.validateHookFile(
+        filePath,
+        workspacePath,
+        verbose,
+        autoFix
+      );
+    }
 
-		return errors;
-	}
+    return errors;
+  }
 
-	/**
-	 * Find all hook files
-	 */
-	private async findHookFiles(hooksDir: string): Promise<string[]> {
-		const { readdir } = await import("node:fs/promises");
-		const files: string[] = [];
+  /**
+   * Find all hook files
+   */
+  private async findHookFiles(hooksDir: string): Promise<string[]> {
+    const { readdir } = await import("node:fs/promises");
+    const files: string[] = [];
 
-		try {
-			const entries = await readdir(hooksDir, { withFileTypes: true });
+    try {
+      const entries = await readdir(hooksDir, { withFileTypes: true });
 
-			for (const entry of entries) {
-				if (
-					entry.isFile() &&
-					HOOK_FILE_REGEX.test(entry.name) &&
-					!entry.name.endsWith(".d.ts") &&
-					!entry.name.includes(".test.") &&
-					!entry.name.includes(".spec.")
-				) {
-					files.push(join(hooksDir, entry.name));
-				}
-			}
-		} catch (error) {
-			// Directory doesn't exist or can't be read
-			if (error instanceof Error) {
-				// TODO: Log could not read hooks directory
-			}
-		}
+      for (const entry of entries) {
+        if (
+          entry.isFile() &&
+          HOOK_FILE_REGEX.test(entry.name) &&
+          !entry.name.endsWith(".d.ts") &&
+          !entry.name.includes(".test.") &&
+          !entry.name.includes(".spec.")
+        ) {
+          files.push(join(hooksDir, entry.name));
+        }
+      }
+    } catch (error) {
+      // Directory doesn't exist or can't be read
+      if (error instanceof Error) {
+        // TODO: Log could not read hooks directory
+      }
+    }
 
-		return files;
-	}
+    return files;
+  }
 
-	/**
-	 * Validate a single hook file
-	 */
-	private async validateHookFile(
-		filePath: string,
-		_workspacePath: string,
-		verbose: boolean,
-		autoFix: boolean,
-	): Promise<number> {
-		// File path relative to workspace: relative(_workspacePath, filePath)
-		let errors = 0;
+  /**
+   * Validate a single hook file
+   */
+  private async validateHookFile(
+    filePath: string,
+    _workspacePath: string,
+    verbose: boolean,
+    autoFix: boolean
+  ): Promise<number> {
+    // File path relative to workspace: relative(_workspacePath, filePath)
+    let errors = 0;
 
-		try {
-			// Check file exists and is readable
-			if (!existsSync(filePath)) {
-				return ++errors;
-			}
+    try {
+      // Check file exists and is readable
+      if (!existsSync(filePath)) {
+        return ++errors;
+      }
 
-			// Check file permissions (executable)
-			const { stat } = await import("node:fs/promises");
-			const stats = await stat(filePath);
+      // Check file permissions (executable)
+      const { stat } = await import("node:fs/promises");
+      const stats = await stat(filePath);
 
-			// On Unix systems, check if file is executable
-			if (process.platform !== "win32") {
-				// File permission check requires bitwise operations
-				const isExecutable = Boolean(stats.mode & 0o111);
-				if (!isExecutable) {
-					if (autoFix) {
-						const { chmod } = await import("node:fs/promises");
-						// File permission setting requires bitwise operations
-						await chmod(filePath, stats.mode | 0o755);
-					} else {
-						errors++;
-					}
-				}
-			}
+      // On Unix systems, check if file is executable
+      if (process.platform !== "win32") {
+        // biome-ignore lint/suspicious/noBitwiseOperators: File permission check requires bitwise operations
+        const isExecutable = Boolean(stats.mode & 0o111);
+        if (!isExecutable) {
+          if (autoFix) {
+            const { chmod } = await import("node:fs/promises");
+            // biome-ignore lint/suspicious/noBitwiseOperators: File permission setting requires bitwise operations
+            await chmod(filePath, stats.mode | 0o755);
+          } else {
+            errors++;
+          }
+        }
+      }
 
-			// Basic syntax check by reading the file
-			const content = await readFile(filePath, "utf-8");
+      // Basic syntax check by reading the file
+      const content = await readFile(filePath, "utf-8");
 
-			// Check for shebang
-			if (!content.startsWith("#!")) {
-				if (autoFix) {
-					const fixedContent = `#!/usr/bin/env bun\n\n${content}`;
-					const { writeFile } = await import("node:fs/promises");
-					await writeFile(filePath, fixedContent);
-				} else {
-					errors++;
-				}
-			}
+      // Check for shebang
+      if (!content.startsWith("#!")) {
+        if (autoFix) {
+          const fixedContent = `#!/usr/bin/env bun\n\n${content}`;
+          const { writeFile } = await import("node:fs/promises");
+          await writeFile(filePath, fixedContent);
+        } else {
+          errors++;
+        }
+      }
 
-			// Check for basic imports (TypeScript/JavaScript)
-			const hasImports =
-				content.includes("@carabiner/hooks-core") ||
-				content.includes("require(") ||
-				content.includes("import");
+      // Check for basic imports (TypeScript/JavaScript)
+      const hasImports =
+        content.includes("@carabiner/hooks-core") ||
+        content.includes("require(") ||
+        content.includes("import");
 
-			if (!hasImports) {
-				errors++;
-			}
+      if (!hasImports) {
+        errors++;
+      }
 
-			// Check for main execution block
-			const hasMainBlock =
-				content.includes("import.meta.main") ||
-				content.includes("require.main === module");
+      // Check for main execution block
+      const hasMainBlock =
+        content.includes("import.meta.main") ||
+        content.includes("require.main === module");
 
-			if (!hasMainBlock) {
-				errors++;
-			}
+      if (!hasMainBlock) {
+        errors++;
+      }
 
-			if (verbose && errors === 0) {
-				// TODO: Log hook file validated
-			}
-		} catch (_error) {
-			// TODO: Log failed to validate hook file
-			errors++;
-		}
+      if (verbose && errors === 0) {
+        // TODO: Log hook file validated
+      }
+    } catch (_error) {
+      // TODO: Log failed to validate hook file
+      errors++;
+    }
 
-		return errors;
-	}
+    return errors;
+  }
 }

--- a/packages/hooks-core/src/builder.ts
+++ b/packages/hooks-core/src/builder.ts
@@ -4,433 +4,433 @@
  */
 
 import type {
-	HookContext,
-	HookEvent,
-	HookHandler,
-	HookMiddleware,
-	HookRegistryEntry,
-	HookResult,
-	HookBuilder as IHookBuilder,
-	ToolName,
+  HookContext,
+  HookEvent,
+  HookHandler,
+  HookMiddleware,
+  HookRegistryEntry,
+  HookResult,
+  HookBuilder as IHookBuilder,
+  ToolName,
 } from "./types.ts";
 
 /**
  * Hook builder implementation with fluent interface
  */
 export class HookBuilder<TEvent extends HookEvent = HookEvent>
-	implements IHookBuilder<TEvent>
+  implements IHookBuilder<TEvent>
 {
-	// Mutated in forEvent method
-	private _event?: TEvent;
-	private _toolName?: ToolName;
-	// Mutated in withHandler method
-	private _handler?: HookHandler<TEvent>;
-	private _timeout?: number;
-	private _condition?: (context: HookContext<TEvent>) => boolean;
-	private _priority = 0;
-	private _enabled = true;
-	// Mutated in forEvent and withMiddleware methods
-	private _middleware: HookMiddleware<HookContext<TEvent>>[] = [];
+  // biome-ignore lint/style/useReadonlyClassProperties: Builder intentionally mutates _event in forEvent method
+  private _event?: TEvent;
+  private _toolName?: ToolName;
+  // biome-ignore lint/style/useReadonlyClassProperties: Builder intentionally mutates _handler in withHandler method
+  private _handler?: HookHandler<TEvent>;
+  private _timeout?: number;
+  private _condition?: (context: HookContext<TEvent>) => boolean;
+  private _priority = 0;
+  private _enabled = true;
+  // biome-ignore lint/style/useReadonlyClassProperties: Builder intentionally mutates _middleware in withMiddleware method
+  private _middleware: HookMiddleware<HookContext<TEvent>>[] = [];
 
-	/**
-	 * Specify the hook event type
-	 */
-	forEvent<E extends HookEvent>(event: E): HookBuilder<E> {
-		const builder = new HookBuilder<E>();
-		builder._event = event;
-		builder._toolName = this._toolName;
-		builder._timeout = this._timeout;
-		builder._priority = this._priority;
-		builder._enabled = this._enabled;
-		builder._middleware = [
-			...(this._middleware as unknown as HookMiddleware<HookContext<E>>[]),
-		];
-		return builder;
-	}
+  /**
+   * Specify the hook event type
+   */
+  forEvent<E extends HookEvent>(event: E): HookBuilder<E> {
+    const builder = new HookBuilder<E>();
+    builder._event = event;
+    builder._toolName = this._toolName;
+    builder._timeout = this._timeout;
+    builder._priority = this._priority;
+    builder._enabled = this._enabled;
+    builder._middleware = [
+      ...(this._middleware as unknown as HookMiddleware<HookContext<E>>[]),
+    ];
+    return builder;
+  }
 
-	/**
-	 * Specify the target tool name
-	 */
-	forTool<T extends ToolName>(toolName: T): HookBuilder<TEvent> {
-		this._toolName = toolName;
-		return this;
-	}
+  /**
+   * Specify the target tool name
+   */
+  forTool<T extends ToolName>(toolName: T): HookBuilder<TEvent> {
+    this._toolName = toolName;
+    return this;
+  }
 
-	/**
-	 * Set the hook handler function
-	 */
-	withHandler<E extends TEvent>(handler: HookHandler<E>): HookBuilder<E> {
-		const builder = this as unknown as HookBuilder<E>;
-		builder._handler = handler;
-		return builder;
-	}
+  /**
+   * Set the hook handler function
+   */
+  withHandler<E extends TEvent>(handler: HookHandler<E>): HookBuilder<E> {
+    const builder = this as unknown as HookBuilder<E>;
+    builder._handler = handler;
+    return builder;
+  }
 
-	/**
-	 * Set execution timeout in milliseconds
-	 */
-	withTimeout(timeout: number): HookBuilder<TEvent> {
-		this._timeout = timeout;
-		return this;
-	}
+  /**
+   * Set execution timeout in milliseconds
+   */
+  withTimeout(timeout: number): HookBuilder<TEvent> {
+    this._timeout = timeout;
+    return this;
+  }
 
-	/**
-	 * Add conditional execution logic
-	 */
-	withCondition(
-		condition: (context: HookContext<TEvent>) => boolean,
-	): HookBuilder<TEvent> {
-		this._condition = condition;
-		return this;
-	}
+  /**
+   * Add conditional execution logic
+   */
+  withCondition(
+    condition: (context: HookContext<TEvent>) => boolean
+  ): HookBuilder<TEvent> {
+    this._condition = condition;
+    return this;
+  }
 
-	/**
-	 * Set hook priority (higher numbers execute first)
-	 */
-	withPriority(priority: number): HookBuilder<TEvent> {
-		this._priority = priority;
-		return this;
-	}
+  /**
+   * Set hook priority (higher numbers execute first)
+   */
+  withPriority(priority: number): HookBuilder<TEvent> {
+    this._priority = priority;
+    return this;
+  }
 
-	/**
-	 * Set hook enabled state
-	 */
-	enabled(enabled = true): HookBuilder<TEvent> {
-		this._enabled = enabled;
-		return this;
-	}
+  /**
+   * Set hook enabled state
+   */
+  enabled(enabled = true): HookBuilder<TEvent> {
+    this._enabled = enabled;
+    return this;
+  }
 
-	/**
-	 * Add middleware to the hook execution
-	 */
-	withMiddleware(
-		middlewareFunc: HookMiddleware<HookContext<TEvent>>,
-	): HookBuilder<TEvent> {
-		this._middleware.push(middlewareFunc);
-		return this;
-	}
+  /**
+   * Add middleware to the hook execution
+   */
+  withMiddleware(
+    middlewareFunc: HookMiddleware<HookContext<TEvent>>
+  ): HookBuilder<TEvent> {
+    this._middleware.push(middlewareFunc);
+    return this;
+  }
 
-	/**
-	 * Build the hook registry entry
-	 */
-	build(): HookRegistryEntry<TEvent> {
-		if (!this._event) {
-			throw new Error("Hook event is required");
-		}
+  /**
+   * Build the hook registry entry
+   */
+  build(): HookRegistryEntry<TEvent> {
+    if (!this._event) {
+      throw new Error("Hook event is required");
+    }
 
-		if (!this._handler) {
-			throw new Error("Hook handler is required");
-		}
+    if (!this._handler) {
+      throw new Error("Hook handler is required");
+    }
 
-		let finalHandler = this._handler;
+    let finalHandler = this._handler;
 
-		// Wrap with condition if provided
-		if (this._condition) {
-			const originalHandler = finalHandler;
-			const condition = this._condition;
+    // Wrap with condition if provided
+    if (this._condition) {
+      const originalHandler = finalHandler;
+      const condition = this._condition;
 
-			finalHandler = async (context: HookContext<TEvent>) => {
-				const shouldExecute = await Promise.resolve(condition(context));
-				if (!shouldExecute) {
-					return { success: true, message: "Hook skipped due to condition" };
-				}
-				return await Promise.resolve(originalHandler(context));
-			};
-		}
+      finalHandler = async (context: HookContext<TEvent>) => {
+        const shouldExecute = await Promise.resolve(condition(context));
+        if (!shouldExecute) {
+          return { success: true, message: "Hook skipped due to condition" };
+        }
+        return await Promise.resolve(originalHandler(context));
+      };
+    }
 
-		// Apply middleware
-		if (this._middleware.length > 0) {
-			finalHandler = this._middleware.reduceRight(
-				(nextHandler, middlewareFunc) => async (context: HookContext<TEvent>) =>
-					await middlewareFunc(
-						context,
-						async (ctx) => await Promise.resolve(nextHandler(ctx)),
-					),
-				finalHandler,
-			);
-		}
+    // Apply middleware
+    if (this._middleware.length > 0) {
+      finalHandler = this._middleware.reduceRight(
+        (nextHandler, middlewareFunc) => async (context: HookContext<TEvent>) =>
+          await middlewareFunc(
+            context,
+            async (ctx) => await Promise.resolve(nextHandler(ctx))
+          ),
+        finalHandler
+      );
+    }
 
-		return {
-			event: this._event,
-			handler: finalHandler,
-			priority: this._priority,
-			enabled: this._enabled,
-			tool: this._toolName, // FIX: Now properly included
-		};
-	}
+    return {
+      event: this._event,
+      handler: finalHandler,
+      priority: this._priority,
+      enabled: this._enabled,
+      tool: this._toolName, // FIX: Now properly included
+    };
+  }
 
-	/**
-	 * Static factory methods for common patterns
-	 */
-	static forPreToolUse(): HookBuilder<"PreToolUse"> {
-		return new HookBuilder<"PreToolUse">().forEvent("PreToolUse");
-	}
+  /**
+   * Static factory methods for common patterns
+   */
+  static forPreToolUse(): HookBuilder<"PreToolUse"> {
+    return new HookBuilder<"PreToolUse">().forEvent("PreToolUse");
+  }
 
-	static forPostToolUse(): HookBuilder<"PostToolUse"> {
-		return new HookBuilder<"PostToolUse">().forEvent("PostToolUse");
-	}
+  static forPostToolUse(): HookBuilder<"PostToolUse"> {
+    return new HookBuilder<"PostToolUse">().forEvent("PostToolUse");
+  }
 
-	static forSessionStart(): HookBuilder<"SessionStart"> {
-		return new HookBuilder<"SessionStart">().forEvent("SessionStart");
-	}
+  static forSessionStart(): HookBuilder<"SessionStart"> {
+    return new HookBuilder<"SessionStart">().forEvent("SessionStart");
+  }
 
-	static forUserPrompt(): HookBuilder<"UserPromptSubmit"> {
-		return new HookBuilder<"UserPromptSubmit">().forEvent("UserPromptSubmit");
-	}
+  static forUserPrompt(): HookBuilder<"UserPromptSubmit"> {
+    return new HookBuilder<"UserPromptSubmit">().forEvent("UserPromptSubmit");
+  }
 }
 
 /**
  * Functional API for creating hooks
  */
 export const createHook = {
-	/**
-	 * Create a PreToolUse hook - supports both universal and tool-specific
-	 */
-	preToolUse<T extends ToolName>(
-		toolOrHandler: T | HookHandler<"PreToolUse">,
-		handler?: HookHandler<"PreToolUse">,
-	): HookRegistryEntry<"PreToolUse"> {
-		if (typeof toolOrHandler === "function") {
-			// Universal hook: createHook.preToolUse(handler)
-			return {
-				event: "PreToolUse",
-				handler: toolOrHandler,
-				priority: 0,
-				enabled: true,
-				tool: undefined, // Universal hook
-			};
-		}
-		// Tool-specific hook: createHook.preToolUse('Bash', handler)
-		if (!handler) {
-			throw new Error("Handler is required when tool is specified");
-		}
-		return {
-			event: "PreToolUse",
-			handler,
-			priority: 0,
-			enabled: true,
-			tool: toolOrHandler,
-		};
-	},
+  /**
+   * Create a PreToolUse hook - supports both universal and tool-specific
+   */
+  preToolUse<T extends ToolName>(
+    toolOrHandler: T | HookHandler<"PreToolUse">,
+    handler?: HookHandler<"PreToolUse">
+  ): HookRegistryEntry<"PreToolUse"> {
+    if (typeof toolOrHandler === "function") {
+      // Universal hook: createHook.preToolUse(handler)
+      return {
+        event: "PreToolUse",
+        handler: toolOrHandler,
+        priority: 0,
+        enabled: true,
+        tool: undefined, // Universal hook
+      };
+    }
+    // Tool-specific hook: createHook.preToolUse('Bash', handler)
+    if (!handler) {
+      throw new Error("Handler is required when tool is specified");
+    }
+    return {
+      event: "PreToolUse",
+      handler,
+      priority: 0,
+      enabled: true,
+      tool: toolOrHandler,
+    };
+  },
 
-	/**
-	 * Create a PostToolUse hook - supports both universal and tool-specific
-	 */
-	postToolUse<T extends ToolName>(
-		toolOrHandler: T | HookHandler<"PostToolUse">,
-		handler?: HookHandler<"PostToolUse">,
-	): HookRegistryEntry<"PostToolUse"> {
-		if (typeof toolOrHandler === "function") {
-			// Universal hook: createHook.postToolUse(handler)
-			return {
-				event: "PostToolUse",
-				handler: toolOrHandler,
-				priority: 0,
-				enabled: true,
-				tool: undefined, // Universal hook
-			};
-		}
-		// Tool-specific hook: createHook.postToolUse('Bash', handler)
-		if (!handler) {
-			throw new Error("Handler is required when tool is specified");
-		}
-		return {
-			event: "PostToolUse",
-			handler,
-			priority: 0,
-			enabled: true,
-			tool: toolOrHandler,
-		};
-	},
+  /**
+   * Create a PostToolUse hook - supports both universal and tool-specific
+   */
+  postToolUse<T extends ToolName>(
+    toolOrHandler: T | HookHandler<"PostToolUse">,
+    handler?: HookHandler<"PostToolUse">
+  ): HookRegistryEntry<"PostToolUse"> {
+    if (typeof toolOrHandler === "function") {
+      // Universal hook: createHook.postToolUse(handler)
+      return {
+        event: "PostToolUse",
+        handler: toolOrHandler,
+        priority: 0,
+        enabled: true,
+        tool: undefined, // Universal hook
+      };
+    }
+    // Tool-specific hook: createHook.postToolUse('Bash', handler)
+    if (!handler) {
+      throw new Error("Handler is required when tool is specified");
+    }
+    return {
+      event: "PostToolUse",
+      handler,
+      priority: 0,
+      enabled: true,
+      tool: toolOrHandler,
+    };
+  },
 
-	/**
-	 * Create a SessionStart hook
-	 */
-	sessionStart(
-		handler: HookHandler<"SessionStart">,
-	): HookRegistryEntry<"SessionStart"> {
-		return HookBuilder.forSessionStart().withHandler(handler).build();
-	},
+  /**
+   * Create a SessionStart hook
+   */
+  sessionStart(
+    handler: HookHandler<"SessionStart">
+  ): HookRegistryEntry<"SessionStart"> {
+    return HookBuilder.forSessionStart().withHandler(handler).build();
+  },
 
-	/**
-	 * Create a UserPromptSubmit hook
-	 */
-	userPromptSubmit(
-		handler: HookHandler<"UserPromptSubmit">,
-	): HookRegistryEntry<"UserPromptSubmit"> {
-		return HookBuilder.forUserPrompt().withHandler(handler).build();
-	},
+  /**
+   * Create a UserPromptSubmit hook
+   */
+  userPromptSubmit(
+    handler: HookHandler<"UserPromptSubmit">
+  ): HookRegistryEntry<"UserPromptSubmit"> {
+    return HookBuilder.forUserPrompt().withHandler(handler).build();
+  },
 
-	/**
-	 * Create a conditional hook
-	 */
-	conditional<TEvent extends HookEvent>(
-		event: TEvent,
-		condition: (context: HookContext<TEvent>) => boolean,
-		handler: HookHandler<TEvent>,
-	): HookRegistryEntry<TEvent> {
-		return new HookBuilder<TEvent>()
-			.forEvent(event)
-			.withCondition(condition)
-			.withHandler(handler)
-			.build();
-	},
+  /**
+   * Create a conditional hook
+   */
+  conditional<TEvent extends HookEvent>(
+    event: TEvent,
+    condition: (context: HookContext<TEvent>) => boolean,
+    handler: HookHandler<TEvent>
+  ): HookRegistryEntry<TEvent> {
+    return new HookBuilder<TEvent>()
+      .forEvent(event)
+      .withCondition(condition)
+      .withHandler(handler)
+      .build();
+  },
 };
 
 /**
  * Declarative hook configuration API
  */
 export type DeclarativeHookConfig<TEvent extends HookEvent = HookEvent> = {
-	event: TEvent;
-	tool?: ToolName;
-	handler: HookHandler<TEvent>;
-	condition?: (context: HookContext<TEvent>) => boolean;
-	timeout?: number;
-	priority?: number;
-	enabled?: boolean;
-	middleware?: HookMiddleware<HookContext<TEvent>>[];
+  event: TEvent;
+  tool?: ToolName;
+  handler: HookHandler<TEvent>;
+  condition?: (context: HookContext<TEvent>) => boolean;
+  timeout?: number;
+  priority?: number;
+  enabled?: boolean;
+  middleware?: HookMiddleware<HookContext<TEvent>>[];
 };
 
 /**
  * Create hook from declarative configuration
  */
 export function defineHook<TEvent extends HookEvent>(
-	config: DeclarativeHookConfig<TEvent>,
+  config: DeclarativeHookConfig<TEvent>
 ): HookRegistryEntry<TEvent> {
-	let builder = new HookBuilder<TEvent>().forEvent(config.event);
+  let builder = new HookBuilder<TEvent>().forEvent(config.event);
 
-	if (config.tool) {
-		builder = builder.forTool(config.tool);
-	}
+  if (config.tool) {
+    builder = builder.forTool(config.tool);
+  }
 
-	builder = builder.withHandler(config.handler);
+  builder = builder.withHandler(config.handler);
 
-	if (config.condition) {
-		builder = builder.withCondition(config.condition);
-	}
+  if (config.condition) {
+    builder = builder.withCondition(config.condition);
+  }
 
-	if (config.timeout) {
-		builder = builder.withTimeout(config.timeout);
-	}
+  if (config.timeout) {
+    builder = builder.withTimeout(config.timeout);
+  }
 
-	if (config.priority !== undefined) {
-		builder = builder.withPriority(config.priority);
-	}
+  if (config.priority !== undefined) {
+    builder = builder.withPriority(config.priority);
+  }
 
-	if (config.enabled !== undefined) {
-		builder = builder.enabled(config.enabled);
-	}
+  if (config.enabled !== undefined) {
+    builder = builder.enabled(config.enabled);
+  }
 
-	if (config.middleware) {
-		for (const middleware of config.middleware) {
-			builder = builder.withMiddleware(middleware);
-		}
-	}
+  if (config.middleware) {
+    for (const middleware of config.middleware) {
+      builder = builder.withMiddleware(middleware);
+    }
+  }
 
-	return builder.build();
+  return builder.build();
 }
 
 /**
  * Common middleware implementations
  */
 export const middleware = {
-	/**
-	 * Logging middleware
-	 */
-	logging<T extends HookContext>(
-		logLevel: "debug" | "info" | "warn" | "error" = "info",
-	): HookMiddleware<T> {
-		return async (context, next) => {
-			// Timing captured but not used - reserved for future logging
-			Date.now();
+  /**
+   * Logging middleware
+   */
+  logging<T extends HookContext>(
+    logLevel: "debug" | "info" | "warn" | "error" = "info"
+  ): HookMiddleware<T> {
+    return async (context, next) => {
+      // Timing captured but not used - reserved for future logging
+      Date.now();
 
-			if (logLevel === "debug" || logLevel === "info") {
-				// Logging handled by pino logger in hook execution
-			}
+      if (logLevel === "debug" || logLevel === "info") {
+        // Logging handled by pino logger in hook execution
+      }
 
-			try {
-				const result = await next(context);
-				// Duration tracking reserved for future logging
+      try {
+        const result = await next(context);
+        // Duration tracking reserved for future logging
 
-				if (logLevel === "debug" || logLevel === "info") {
-					// Success logging handled by pino logger
-				}
+        if (logLevel === "debug" || logLevel === "info") {
+          // Success logging handled by pino logger
+        }
 
-				return result;
-			} catch (error) {
-				// Duration tracking reserved for future logging
+        return result;
+      } catch (error) {
+        // Duration tracking reserved for future logging
 
-				if (logLevel !== "error") {
-					// Error logging handled by pino logger
-				}
+        if (logLevel !== "error") {
+          // Error logging handled by pino logger
+        }
 
-				throw error;
-			}
-		};
-	},
+        throw error;
+      }
+    };
+  },
 
-	/**
-	 * Timing middleware
-	 */
-	timing<T extends HookContext>(): HookMiddleware<T> {
-		return async (context, next) => {
-			const start = Date.now();
-			const result = await next(context);
-			const duration = Date.now() - start;
+  /**
+   * Timing middleware
+   */
+  timing<T extends HookContext>(): HookMiddleware<T> {
+    return async (context, next) => {
+      const start = Date.now();
+      const result = await next(context);
+      const duration = Date.now() - start;
 
-			return {
-				...result,
-				metadata: {
-					...result.metadata,
-					duration,
-				},
-			};
-		};
-	},
+      return {
+        ...result,
+        metadata: {
+          ...result.metadata,
+          duration,
+        },
+      };
+    };
+  },
 
-	/**
-	 * Error handling middleware
-	 */
-	errorHandling<T extends HookContext>(
-		onError?: (error: Error, context: T) => HookResult,
-	): HookMiddleware<T> {
-		return async (context, next) => {
-			try {
-				return await next(context);
-			} catch (error) {
-				if (onError && error instanceof Error) {
-					return onError(error, context);
-				}
+  /**
+   * Error handling middleware
+   */
+  errorHandling<T extends HookContext>(
+    onError?: (error: Error, context: T) => HookResult
+  ): HookMiddleware<T> {
+    return async (context, next) => {
+      try {
+        return await next(context);
+      } catch (error) {
+        if (onError && error instanceof Error) {
+          return onError(error, context);
+        }
 
-				return {
-					success: false,
-					message: error instanceof Error ? error.message : "Unknown error",
-					block: context.event === "PreToolUse",
-				};
-			}
-		};
-	},
+        return {
+          success: false,
+          message: error instanceof Error ? error.message : "Unknown error",
+          block: context.event === "PreToolUse",
+        };
+      }
+    };
+  },
 
-	/**
-	 * Validation middleware
-	 */
-	validation<T extends HookContext>(
-		validator: (context: T) => boolean | Promise<boolean>,
-		errorMessage = "Hook validation failed",
-	): HookMiddleware<T> {
-		return async (context, next) => {
-			const isValid = await Promise.resolve(validator(context));
+  /**
+   * Validation middleware
+   */
+  validation<T extends HookContext>(
+    validator: (context: T) => boolean | Promise<boolean>,
+    errorMessage = "Hook validation failed"
+  ): HookMiddleware<T> {
+    return async (context, next) => {
+      const isValid = await Promise.resolve(validator(context));
 
-			if (!isValid) {
-				return {
-					success: false,
-					message: errorMessage,
-					block: context.event === "PreToolUse",
-				};
-			}
+      if (!isValid) {
+        return {
+          success: false,
+          message: errorMessage,
+          block: context.event === "PreToolUse",
+        };
+      }
 
-			return next(context);
-		};
-	},
+      return next(context);
+    };
+  },
 };
 
 /**


### PR DESCRIPTION
- Add biome-ignore for hasChanges condition check in init.ts
- Add biome-ignore for hasErrors condition check in validate.ts
- Add biome-ignore for bitwise operations in validate.ts file permissions
- Add biome-ignore for mutable builder properties in builder.ts

These suppressions are necessary because:
- Biome cannot infer that hasChanges/hasErrors are mutated in loops
- Bitwise operations are required for Unix file permissions
- Builder pattern requires mutable properties for fluent API

🤖 Generated with Claude Code
via Happy

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>