### PR TITLE
fix: remove legacy @grapple and @outfitter references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
                   if (!obj) return;
                   for (const k of Object.keys(obj)) {
                     // Update local workspace deps (adjust the predicate to your scopes/names)
-                    if (/^@grapple\//.test(k) || /^@outfitter\//.test(k) || /^@carabiner\//.test(k)) {
+                    if (/^@carabiner\//.test(k)) {
                       obj[k] = '$new_version';
                     }
                   }

--- a/packages/hooks-core/src/index.ts
+++ b/packages/hooks-core/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @outfitter/hooks-core
+ * @carabiner/hooks-core
  * Core TypeScript types and runtime utilities for Claude Code hooks
  */
 

--- a/packages/hooks-testing/src/index.ts
+++ b/packages/hooks-testing/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @outfitter/hooks-testing
+ * @carabiner/hooks-testing
  * Testing utilities for Claude Code hooks
  */
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @outfitter/types - Type system foundation for Claude Code hooks
+ * @carabiner/types - Type system foundation for Claude Code hooks
  *
  * This package provides:
  * - Branded types for compile-time safety and runtime validation


### PR DESCRIPTION
## Summary

- Removes @grapple check from release workflow (closes #64, #65)
- Updates @outfitter references to @carabiner in source files (closes #68)
- Rebuilds packages to update dist files

## Context

These were the last remaining legacy references after the main rename in PR #75. This completes the full migration to the @carabiner namespace.

## Changes

- : Remove @grapple and @outfitter from package version bumping logic
- : Update package comment from @outfitter to @carabiner
- : Update package comment from @outfitter to @carabiner  
- : Update package comment from @outfitter to @carabiner

## Test Results

✅ All 752 tests passing
✅ Linting passes with no errors
✅ Build successful

Closes #64, Closes #65, Closes #68

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release automation to only bump @carabiner-scoped dependencies during versioning.

- Documentation
  - Refreshed package headers to reflect the @carabiner namespace across core hooks, testing utilities, and types packages.

No functional or API changes; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->