### PR TITLE
feat: add comprehensive package metadata for npm discoverability

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -1,4 +1,45 @@
 {
   "$schema": "./node_modules/syncpack/schema.json",
-  "indent": "  "
+  "indent": "  ",
+  "semverGroups": [
+    {
+      "label": "Use caret ranges for all dependencies",
+      "packages": ["**"],
+      "dependencies": ["**"],
+      "dependencyTypes": ["dev", "prod", "peer"],
+      "range": "^"
+    }
+  ],
+  "versionGroups": [
+    {
+      "label": "Ensure TypeScript version consistency",
+      "packages": ["**"],
+      "dependencies": ["typescript"],
+      "policy": "same"
+    },
+    {
+      "label": "Ensure type-fest version consistency",
+      "packages": ["**"],
+      "dependencies": ["type-fest"],
+      "policy": "same"
+    },
+    {
+      "label": "Ensure ultracite version consistency",
+      "packages": ["**"],
+      "dependencies": ["ultracite"],
+      "policy": "same"
+    },
+    {
+      "label": "Ensure @types/node version consistency",
+      "packages": ["**"],
+      "dependencies": ["@types/node"],
+      "policy": "same"
+    },
+    {
+      "label": "Ensure @types/bun version consistency",
+      "packages": ["**"],
+      "dependencies": ["@types/bun"],
+      "policy": "same"
+    }
+  ]
 }

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -3,11 +3,18 @@
   "indent": "  ",
   "semverGroups": [
     {
-      "label": "Use caret ranges for all dependencies",
+      "label": "Use caret ranges for external dependencies",
       "packages": ["**"],
-      "dependencies": ["**"],
-      "dependencyTypes": ["dev", "prod", "peer"],
+      "dependencies": ["**", "!@carabiner/*"],
+      "dependencyTypes": ["dev", "prod"],
       "range": "^"
+    },
+    {
+      "label": "Internal workspace packages use exact versions",
+      "packages": ["**"],
+      "dependencies": ["@carabiner/*"],
+      "dependencyTypes": ["prod", "peer"],
+      "range": ""
     }
   ],
   "versionGroups": [
@@ -39,6 +46,12 @@
       "label": "Ensure @types/bun version consistency",
       "packages": ["**"],
       "dependencies": ["@types/bun"],
+      "policy": "same"
+    },
+    {
+      "label": "Ensure bun-types version consistency",
+      "packages": ["**"],
+      "dependencies": ["bun-types"],
       "policy": "same"
     }
   ]

--- a/packages/error-management/package.json
+++ b/packages/error-management/package.json
@@ -8,7 +8,7 @@
     "type-fest": "^4.41.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "*",
     "@types/node": "^24.3.1",
     "typescript": "^5.9.2"
   },

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/execution",
   "description": "Simplified execution engine for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/hooks-core": "0.1.0-alpha",
     "@carabiner/protocol": "0.1.0-alpha",
@@ -24,8 +25,13 @@
     "dist/",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "execution",
     "hooks",
     "typescript"
@@ -38,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/grapple.git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
     "directory": "packages/execution"
   },
   "scripts": {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -25,7 +25,7 @@
     "dist/",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/execution#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/hooks-cli/package.json
+++ b/packages/hooks-cli/package.json
@@ -33,7 +33,7 @@
     "templates",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/hooks-cli#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/hooks-cli/package.json
+++ b/packages/hooks-cli/package.json
@@ -2,10 +2,11 @@
   "name": "@carabiner/hooks-cli",
   "description": "CLI tools for Carabiner hooks development",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
   "bin": {
     "carabiner": "./bin/carabiner.mjs"
   },
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/hooks-config": "0.1.0-alpha",
     "@carabiner/hooks-core": "0.1.0-alpha",
@@ -32,16 +33,26 @@
     "templates",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
     "cli",
-    "development-tools",
-    "hooks"
+    "developer-tools",
+    "hooks",
+    "typescript"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/hooks-cli"
   },
   "scripts": {
     "build": "bun run build:clean && bun run build:tsc",

--- a/packages/hooks-config/package.json
+++ b/packages/hooks-config/package.json
@@ -22,7 +22,7 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/hooks-config#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/hooks-config/package.json
+++ b/packages/hooks-config/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/hooks-config",
   "description": "Configuration management for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/error-management": "0.1.0-alpha",
     "@carabiner/hooks-core": "0.1.0-alpha"
@@ -21,15 +22,26 @@
     "dist",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
     "configuration",
-    "hooks"
+    "developer-tools",
+    "hooks",
+    "typescript"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/hooks-config"
   },
   "scripts": {
     "build": "bun run build:clean && bun run build:tsc",

--- a/packages/hooks-core/package.json
+++ b/packages/hooks-core/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/hooks-core",
   "description": "Core TypeScript types and runtime utilities for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "pino": "^9.8.0"
   },
@@ -31,8 +32,13 @@
     "dist",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "types",
     "typescript"
@@ -44,6 +50,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/hooks-core"
   },
   "scripts": {
     "build": "bun run build:clean && bun run build:tsc",

--- a/packages/hooks-core/package.json
+++ b/packages/hooks-core/package.json
@@ -32,7 +32,7 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/hooks-core#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/hooks-testing/package.json
+++ b/packages/hooks-testing/package.json
@@ -22,7 +22,7 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/hooks-testing#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/hooks-testing/package.json
+++ b/packages/hooks-testing/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/hooks-testing",
   "description": "Testing utilities for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/hooks-core": "0.1.0-alpha",
     "@carabiner/hooks-validators": "0.1.0-alpha"
@@ -21,10 +22,16 @@
     "dist",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "testing",
+    "typescript",
     "utilities"
   ],
   "license": "MIT",
@@ -34,6 +41,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/hooks-testing"
   },
   "scripts": {
     "build": "bun run build:clean && bun run build:tsc",

--- a/packages/hooks-validators/package.json
+++ b/packages/hooks-validators/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/hooks-validators",
   "description": "Security and validation utilities for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt.galligan@gmail.com>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/hooks-core": "0.1.0-alpha"
   },
@@ -20,16 +21,27 @@
     "dist",
     "README.md"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "security",
+    "typescript",
     "validation"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/hooks-validators"
   },
   "scripts": {
     "build": "bun run build:clean && bun run build:tsc",

--- a/packages/hooks-validators/package.json
+++ b/packages/hooks-validators/package.json
@@ -21,7 +21,7 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/hooks-validators#readme",
   "keywords": [
     "ai-tools",
     "automation",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -9,7 +9,7 @@
     "@carabiner/types": "0.1.0-alpha"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "*",
     "typescript": "^5.9.2"
   },
   "exports": {
@@ -21,7 +21,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/protocol#readme",
   "keywords": [
     "abstraction",
     "ai-tools",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -2,8 +2,8 @@
   "name": "@carabiner/protocol",
   "description": "Protocol abstraction layer for Carabiner hooks I/O",
   "version": "0.1.0-alpha",
-  "author": "Outfitter",
-  "bugs": "https://github.com/outfitter-dev/grapple/issues",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/schemas": "0.1.0-alpha",
     "@carabiner/types": "0.1.0-alpha"
@@ -21,13 +21,18 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/outfitter-dev/grapple/tree/main/packages/protocol#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
     "abstraction",
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "io",
-    "protocol"
+    "protocol",
+    "typescript"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
@@ -37,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outfitter-dev/grapple.git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
     "directory": "packages/protocol"
   },
   "scripts": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -9,7 +9,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "*",
     "typescript": "^5.9.2"
   },
   "exports": {
@@ -49,6 +49,9 @@
   ],
   "license": "MIT",
   "main": "./dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/outfitter-dev/carabiner.git",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/schemas",
   "description": "Zod validation schemas for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt@outfitter.dev>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "@carabiner/types": "0.1.0-alpha",
     "zod": "^3.24.1"
@@ -33,15 +34,26 @@
     "dist",
     "src"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "schemas",
+    "typescript",
     "validation",
     "zod"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/schemas"
+  },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "dev": "tsc --project tsconfig.build.json --watch",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,7 +2,8 @@
   "name": "@carabiner/types",
   "description": "Type system foundation for Carabiner hooks",
   "version": "0.1.0-alpha",
-  "author": "Matt Galligan <matt@outfitter.dev>",
+  "author": "Outfitter Dev <hello@outfitter.dev>",
+  "bugs": "https://github.com/outfitter-dev/carabiner/issues",
   "dependencies": {
     "type-fest": "^4.41.0"
   },
@@ -36,15 +37,25 @@
     "dist",
     "src"
   ],
+  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
   "keywords": [
+    "ai-tools",
+    "automation",
     "branded-types",
     "carabiner",
+    "claude-code",
+    "developer-tools",
     "hooks",
     "types",
     "typescript"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/carabiner.git",
+    "directory": "packages/types"
+  },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "dev": "tsc --project tsconfig.build.json --watch",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,7 @@
     "type-fest": "^4.41.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "*",
     "typescript": "^5.9.2"
   },
   "exports": {
@@ -37,7 +37,7 @@
     "dist",
     "src"
   ],
-  "homepage": "https://github.com/outfitter-dev/carabiner#readme",
+  "homepage": "https://github.com/outfitter-dev/carabiner/tree/main/packages/types#readme",
   "keywords": [
     "ai-tools",
     "automation",
@@ -51,6 +51,9 @@
   ],
   "license": "MIT",
   "main": "./dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/outfitter-dev/carabiner.git",


### PR DESCRIPTION
Adds comprehensive metadata to all 9 packages to improve npm discoverability and standardize package information.

## Changes

- ✅ Added claude-code, ai-tools, automation, developer-tools keywords
- ✅ Added homepage, repository, and bugs URLs consistently
- ✅ Standardized author to 'Outfitter Dev <hello@outfitter.dev>'
- ✅ Fixed incorrect repository URLs (grapple → carabiner)
- ✅ Maintained package-specific keywords while adding standard metadata

Resolves #26

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized package metadata across packages: updated author to Outfitter Dev, added homepage and issue tracker links, refreshed repository details, and expanded keywords for discoverability.
  - Implemented dependency version policies to enforce consistent semver ranges and version parity for key tooling libraries across the workspace.

- Documentation
  - Updated package homepages to point to the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->