### PR TITLE
fix: address PR feedback - fix timeout promise handling and TypeScript errors

### DIFF
--- a/packages/hooks-core/src/builder.ts
+++ b/packages/hooks-core/src/builder.ts
@@ -199,8 +199,10 @@ export class HookBuilder<TInput extends HookInput = HookInput>
         toolUseId?: string,
         _options?: { signal?: AbortSignal }
       ) => {
+        let timeoutId: NodeJS.Timeout | undefined;
+
         const timeoutPromise = new Promise<HookJSONOutput>((_, reject) => {
-          setTimeout(
+          timeoutId = setTimeout(
             () =>
               reject(new Error(`Hook execution timed out after ${timeout}ms`)),
             timeout
@@ -208,13 +210,25 @@ export class HookBuilder<TInput extends HookInput = HookInput>
         });
 
         try {
-          return await Promise.race([
+          const result = await Promise.race([
             originalHandler(input, toolUseId, {
               signal: new AbortController().signal,
             }),
             timeoutPromise,
           ]);
+
+          // Clear the timeout if the handler completes successfully
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+          }
+
+          return result;
         } catch (error) {
+          // Clear the timeout on error as well
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+          }
+
           if (error instanceof Error && error.message.includes("timed out")) {
             return {
               continue: false,

--- a/packages/hooks-core/src/providers/claude-adapter.ts
+++ b/packages/hooks-core/src/providers/claude-adapter.ts
@@ -8,6 +8,7 @@ import type {
   HookJSONOutput,
   PostToolUseHookInput,
   PreToolUseHookInput,
+  ToolInput,
 } from "../types";
 import {
   isPostToolUseInput,
@@ -84,7 +85,7 @@ function resolveToolContext(
     const preInput = input as PreToolUseHookInput;
     return {
       name: preInput.tool_name,
-      input: preInput.tool_input,
+      input: preInput.tool_input as ToolInput | Record<string, unknown>,
     };
   }
 
@@ -92,7 +93,7 @@ function resolveToolContext(
     const postInput = input as PostToolUseHookInput;
     return {
       name: postInput.tool_name,
-      input: postInput.tool_input,
+      input: postInput.tool_input as ToolInput | Record<string, unknown>,
       response: postInput.tool_response,
     };
   }


### PR DESCRIPTION
- Clear timeout when handler completes to avoid unhandled rejections
- Fix TypeScript errors in claude-adapter by properly casting tool_input
- Import ToolInput type for proper type safety