### PR TITLE
fix: allow hook event shorthand

### DIFF
--- a/packages/execution/examples/simple-security-hook.ts
+++ b/packages/execution/examples/simple-security-hook.ts
@@ -15,33 +15,8 @@
  * 2. Expected output: Hook should block the dangerous command
  */
 
-import type { HookHandler } from "@carabiner/types";
-
-type BashToolInput = {
-  readonly command: string;
-  readonly description?: string;
-  readonly timeout?: number;
-};
-
-type BashContext = {
-  readonly event: string;
-  readonly toolName: string;
-  readonly toolInput: BashToolInput;
-  readonly sessionId: string;
-  readonly cwd: string;
-  readonly environment: Record<string, string>;
-};
-
-type NonBashContext = {
-  readonly event: string;
-  readonly toolName: string;
-  readonly toolInput: Record<string, unknown>;
-  readonly sessionId: string;
-  readonly cwd: string;
-  readonly environment: Record<string, string>;
-};
-
-type TestContext = BashContext | NonBashContext;
+import type { PreToolUseHookInput } from "@carabiner/hooks-core";
+import { createHookContext, HookResults } from "@carabiner/hooks-core";
 
 // We would normally use:
 // import { runHook } from '@carabiner/execution';
@@ -54,21 +29,16 @@ import {
 } from "../src/metrics";
 
 // Define our security hook handler
-const securityHook: HookHandler = (context) => {
+const securityHook = (context: ReturnType<typeof createHookContext>) => {
   // Only check PreToolUse events for Bash
   if (context.event !== "PreToolUse" || context.toolName !== "Bash") {
-    return { success: true, message: "Not applicable to this tool/event" };
+    return HookResults.success("Not applicable to this tool/event");
   }
 
-  // Type guard to ensure context has the expected structure
-  if (!("toolInput" in context && context.toolInput)) {
-    return { success: true, message: "No tool input to validate" };
-  }
-
-  const bashContext = context as BashContext;
-  const command = bashContext.toolInput.command;
+  const command = (context.toolInput as { command?: string } | undefined)
+    ?.command;
   if (!command || typeof command !== "string") {
-    return { success: true, message: "No command to validate" };
+    return HookResults.success("No command to validate");
   }
 
   // Define dangerous command patterns
@@ -90,72 +60,62 @@ const securityHook: HookHandler = (context) => {
   // Check for dangerous patterns
   for (const pattern of dangerousPatterns) {
     if (pattern.test(command)) {
-      return {
-        success: false,
-        block: true,
-        message: `Security violation: Command blocked due to dangerous pattern - ${pattern.source}`,
-      };
+      return HookResults.block(
+        `Security violation: Command blocked due to dangerous pattern - ${pattern.source}`
+      );
     }
   }
 
   // Additional checks for suspicious combinations
   if (command.includes("sudo") && command.includes("rm")) {
-    return {
-      success: false,
-      block: true,
-      message: "Security violation: sudo rm commands are not allowed",
-    };
+    return HookResults.block(
+      "Security violation: sudo rm commands are not allowed"
+    );
   }
-  return {
-    success: true,
-    message: `Command "${command.slice(0, 50)}${command.length > 50 ? "..." : ""}" approved by security hook`,
-  };
+  return HookResults.success(
+    `Command "${command.slice(0, 50)}${command.length > 50 ? "..." : ""}" approved by security hook`
+  );
 };
 
 // Example usage function for testing
 export async function runSecurityExample() {
-  const testCases: Array<{ name: string; context: TestContext }> = [
+  const testCases: Array<{
+    name: string;
+    input: {
+      sessionId: string;
+      toolName: string;
+      toolInput: Record<string, unknown>;
+    };
+  }> = [
     {
       name: "Safe command",
-      context: {
-        event: "PreToolUse" as const,
-        toolName: "Bash",
+      input: {
         sessionId: "example-1",
-        cwd: "/tmp",
-        environment: {},
+        toolName: "Bash",
         toolInput: { command: "ls -la" },
       },
     },
     {
       name: "Dangerous rm -rf command",
-      context: {
-        event: "PreToolUse" as const,
-        toolName: "Bash",
+      input: {
         sessionId: "example-2",
-        cwd: "/tmp",
-        environment: {},
+        toolName: "Bash",
         toolInput: { command: "rm -rf /" },
       },
     },
     {
       name: "Suspicious sudo rm command",
-      context: {
-        event: "PreToolUse" as const,
-        toolName: "Bash",
+      input: {
         sessionId: "example-3",
-        cwd: "/tmp",
-        environment: {},
+        toolName: "Bash",
         toolInput: { command: "sudo rm -f /important-file" },
       },
     },
     {
       name: "Non-Bash tool (should pass through)",
-      context: {
-        event: "PreToolUse" as const,
-        toolName: "Write",
+      input: {
         sessionId: "example-4",
-        cwd: "/tmp",
-        environment: {},
+        toolName: "Write",
         toolInput: { file_path: "/tmp/test.txt", content: "Hello" },
       },
     },
@@ -167,14 +127,27 @@ export async function runSecurityExample() {
     const timer = new ExecutionTimer();
     const memoryBefore = snapshotMemoryUsage();
 
+    const hookInput: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: testCase.input.sessionId,
+      transcript_path: "/tmp/transcript.md",
+      cwd: "/tmp",
+      tool_name: testCase.input.toolName,
+      tool_input: testCase.input.toolInput,
+    };
+
+    const context = createHookContext(hookInput, undefined, {
+      environment: { CLAUDE_PROJECT_DIR: "/tmp" },
+    });
+
     try {
-      const result = await securityHook(testCase.context);
+      const result = await securityHook(context);
 
       const memoryAfter = snapshotMemoryUsage();
 
       // Collect metrics
       collector.record(
-        testCase.context,
+        context,
         result,
         timer.getTiming(),
         memoryBefore,
@@ -184,14 +157,6 @@ export async function runSecurityExample() {
       // Additional event recording could be implemented here if needed
     } catch (_error) {
       // Error in test execution - expected for some test cases
-    }
-  }
-  const stats = collector.getAggregateMetrics();
-
-  if (stats.topErrors.length > 0) {
-    for (const _error of stats.topErrors) {
-      // Log error statistics for debugging
-      collector.recordEvent("error_stat", "Found error in statistics");
     }
   }
 }

--- a/packages/execution/src/metrics.ts
+++ b/packages/execution/src/metrics.ts
@@ -6,7 +6,18 @@
  * minimal impact on execution performance.
  */
 
-import type { HookContext, HookEvent, HookResult } from "@carabiner/types";
+import type {
+  HookContext as CoreHookContext,
+  HookResult as CoreHookResult,
+} from "@carabiner/hooks-core";
+import type {
+  HookContext as TypesHookContext,
+  HookResult as TypesHookResult,
+} from "@carabiner/types";
+
+type CompatibleHookContext = TypesHookContext | CoreHookContext;
+type CompatibleHookResult = TypesHookResult | CoreHookResult;
+type MetricsHookEvent = CompatibleHookContext["event"];
 
 /**
  * Execution timing information
@@ -48,7 +59,7 @@ export type ExecutionMetrics = {
   /** Unique execution ID */
   readonly id: string;
   /** Hook event that was executed */
-  readonly event: HookEvent;
+  readonly event: MetricsHookEvent;
   /** Tool name (if applicable) */
   readonly toolName?: string;
   /** Whether execution was successful */
@@ -96,7 +107,7 @@ export type AggregateMetrics = {
   /** Most common error codes */
   readonly topErrors: Array<{ code: string; count: number }>;
   /** Breakdown by hook event */
-  readonly eventBreakdown: Record<HookEvent, number>;
+  readonly eventBreakdown: Partial<Record<MetricsHookEvent, number>>;
   /** Average memory usage */
   readonly averageMemoryUsage: MemoryUsage;
   /** Time range of collected metrics */
@@ -246,8 +257,8 @@ export class MetricsCollector {
    * @param additionalContext - Additional context data
    */
   record(
-    context: HookContext,
-    result: HookResult,
+    context: CompatibleHookContext,
+    result: CompatibleHookResult,
     timing: ExecutionTiming,
     memoryBefore: MemoryUsage,
     memoryAfter: MemoryUsage,
@@ -256,14 +267,14 @@ export class MetricsCollector {
     if (!this.enabled) {
       return;
     }
+    const success = result.success !== false;
+    const message = "message" in result ? result.message : undefined;
     const metrics: ExecutionMetrics = {
       id: this.generateId(),
       event: context.event,
       toolName: "toolName" in context ? context.toolName : undefined,
-      success: result.success,
-      errorCode: result.success
-        ? undefined
-        : this.extractErrorCode(result.message),
+      success,
+      errorCode: success ? undefined : this.extractErrorCode(message),
       timing,
       memoryBefore,
       memoryAfter,
@@ -341,7 +352,7 @@ export class MetricsCollector {
     }
 
     // Count events
-    const eventCounts: Partial<Record<HookEvent, number>> = {};
+    const eventCounts: Partial<Record<MetricsHookEvent, number>> = {};
     for (const metric of metricsToAnalyze) {
       const count = eventCounts[metric.event] || 0;
       eventCounts[metric.event] = count + 1;
@@ -363,7 +374,7 @@ export class MetricsCollector {
         .map(([code, count]) => ({ code, count }))
         .sort((a, b) => b.count - a.count)
         .slice(0, 10),
-      eventBreakdown: eventCounts as Record<HookEvent, number>,
+      eventBreakdown: eventCounts,
       averageMemoryUsage: this.calculateAverageMemoryUsage(metricsToAnalyze),
       timeRange: timeRange || {
         start: Math.min(...metricsToAnalyze.map((m) => m.timestamp)),
@@ -452,7 +463,7 @@ export class MetricsCollector {
       minDuration: 0,
       maxDuration: 0,
       topErrors: [],
-      eventBreakdown: {} as Record<HookEvent, number>,
+      eventBreakdown: {} as Partial<Record<MetricsHookEvent, number>>,
       averageMemoryUsage: { heapUsed: 0, heapTotal: 0, external: 0, rss: 0 },
       timeRange: timeRange || { start: 0, end: 0 },
     };

--- a/packages/hooks-cli/bin/carabiner.ts
+++ b/packages/hooks-cli/bin/carabiner.ts
@@ -13,7 +13,7 @@
 const args = Bun.argv.slice(2);
 
 // Help text
-if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+if (args[0] === "--help" || args[0] === "-h") {
   // Prefer help from source so it's always in sync
   const { renderHelp } = await import("../src/help.ts");
   console.log(renderHelp());
@@ -131,6 +131,17 @@ process.stdin.on('end', () => {
 // Main execution
 async function main() {
   const command = args[0];
+
+  if (!command) {
+    console.error(
+      JSON.stringify({
+        status: "failure",
+        message: "No hook command provided",
+        blocking: true,
+      })
+    );
+    process.exit(1);
+  }
 
   if (command === "list") {
     listHooks();

--- a/packages/hooks-config/src/__tests__/placeholder.test.ts
+++ b/packages/hooks-config/src/__tests__/placeholder.test.ts
@@ -84,7 +84,7 @@ describe("ConfigManager - Immutability Tests", () => {
   });
 
   test("should create immutable updates in toggleHook for tool-specific hooks", async () => {
-    const _initialConfig = await configManager.load();
+    await configManager.load();
 
     // Ensure we have a tool config to toggle
     await configManager.setHookConfig("PreToolUse", "Bash", {

--- a/packages/hooks-core/src/__tests__/adapter.test.ts
+++ b/packages/hooks-core/src/__tests__/adapter.test.ts
@@ -144,9 +144,12 @@ describe("claudeProviderAdapter.toProviderOutput", () => {
 describe("provider registry", () => {
   test("registerDefaultHookProviders seeds the default claude adapter", () => {
     const provider = getDefaultHookProvider();
-    expect(provider).not.toBeNull();
-    expect(provider?.id).toBe("claude");
-    expect(provider).toBe(getHookProvider("claude"));
+    expect(provider).toBeDefined();
+    if (!provider) {
+      throw new Error("Default provider not registered");
+    }
+    expect(provider.id).toBe("claude");
+    expect(getHookProvider("claude")).toBe(provider);
   });
 
   test("registerHookProvider prevents duplicate registrations by default", () => {

--- a/packages/hooks-core/src/__tests__/builder.test.ts
+++ b/packages/hooks-core/src/__tests__/builder.test.ts
@@ -10,21 +10,17 @@ import {
   hook,
   middleware,
 } from "../builder";
-import { claudeProviderAdapter } from "../providers";
-import { HookResults } from "../runtime";
-import type { HookContext, PreToolUseHookInput } from "../types";
+import { createHookContext as buildHookContext, HookResults } from "../runtime";
+import type { HookResult, PreToolUseHookInput } from "../types";
 
-// Helper function to create proper HookContext from PreToolUseHookInput
-function createHookContext(input: PreToolUseHookInput): HookContext {
-  const normalized = claudeProviderAdapter.fromProviderInput(input, {
-    CLAUDE_PROJECT_DIR: process.cwd(),
-  });
-  return {
-    ...normalized,
-    toolName: normalized.tool?.name,
-    toolInput: normalized.tool?.input,
-    rawInput: input,
-  } as HookContext;
+function expectSyncResult(result: HookResult) {
+  if (
+    "async" in (result as Record<string, unknown>) &&
+    (result as Record<string, unknown>).async === true
+  ) {
+    throw new Error("Expected synchronous hook result");
+  }
+  return result as Extract<HookResult, { continue?: boolean }>;
 }
 
 // Helper function to check continue status
@@ -122,7 +118,7 @@ describe("HookBuilder", () => {
       tool_input: { command: "test" },
     };
 
-    const bashContext = createHookContext(bashInput);
+    const bashContext = buildHookContext(bashInput);
     const result = await built.handler(bashContext, undefined, {
       signal: new AbortController().signal,
     });
@@ -134,7 +130,7 @@ describe("HookBuilder", () => {
       tool_name: "Write",
     };
 
-    const writeContext = createHookContext(writeInput);
+    const writeContext = buildHookContext(writeInput);
     const writeResult = await built.handler(writeContext, undefined, {
       signal: new AbortController().signal,
     });
@@ -261,7 +257,7 @@ describe("createHook - Functional API", () => {
       tool_input: { command: "test" },
     };
 
-    const bashContext = createHookContext(bashInput);
+    const bashContext = buildHookContext(bashInput);
     const result = await hook.handler(bashContext, undefined, {
       signal: new AbortController().signal,
     });
@@ -321,11 +317,13 @@ describe("defineHook - Declarative API", () => {
       tool_input: { command: "test" },
     };
 
-    const result = await hook.handler(input, undefined, {
+    const context = buildHookContext(input);
+
+    const result = await hook.handler(context, undefined, {
       signal: new AbortController().signal,
     });
     expect(conditionChecked).toBe(true);
-    expect(result.continue).toBe(true);
+    expect(expectSyncResult(result).continue).toBe(true);
   });
 
   test("should define hook with middleware", async () => {
@@ -344,7 +342,7 @@ describe("defineHook - Declarative API", () => {
       tool_input: { command: "test" },
     };
 
-    const context = createHookContext(input);
+    const context = buildHookContext(input);
     const result = await hook.handler(context, undefined, {
       signal: new AbortController().signal,
     });
@@ -373,7 +371,7 @@ describe("Middleware", () => {
       tool_input: { command: "test" },
     };
 
-    const context = createHookContext(input);
+    const context = buildHookContext(input);
     const result = await hook.handler(context, undefined, {
       signal: new AbortController().signal,
     });
@@ -398,7 +396,7 @@ describe("Middleware", () => {
       tool_input: { command: "test" },
     };
 
-    const context = createHookContext(input);
+    const context = buildHookContext(input);
     const result = await hook.handler(context, undefined, {
       signal: new AbortController().signal,
     });
@@ -427,7 +425,7 @@ describe("Middleware", () => {
       tool_input: { command: "test" },
     };
 
-    const bashContext = createHookContext(bashInput);
+    const bashContext = buildHookContext(bashInput);
     const bashResult = await hook.handler(bashContext, undefined, {
       signal: new AbortController().signal,
     });
@@ -438,7 +436,7 @@ describe("Middleware", () => {
       tool_name: "Write",
     };
 
-    const writeContext = createHookContext(writeInput);
+    const writeContext = buildHookContext(writeInput);
     const writeResult = await hook.handler(writeContext, undefined, {
       signal: new AbortController().signal,
     });
@@ -486,7 +484,7 @@ describe("Middleware", () => {
       tool_input: { command: "test" },
     };
 
-    const context = createHookContext(input);
+    const context = buildHookContext(input);
     await hook.handler(context, undefined, {
       signal: new AbortController().signal,
     });

--- a/packages/hooks-core/src/__tests__/runtime.test.ts
+++ b/packages/hooks-core/src/__tests__/runtime.test.ts
@@ -14,48 +14,83 @@ import {
   outputHookResult,
   safeHookExecution,
 } from "../runtime";
-import type { HookHandler } from "../types";
+import type {
+  HookHandler,
+  HookResult,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SessionStartHookInput,
+} from "../types";
+
+function expectSyncResult(result: HookResult) {
+  if ((result as { async?: boolean }).async === true) {
+    throw new Error("Expected synchronous hook result");
+  }
+  return result as Extract<HookResult, { continue?: boolean }>;
+}
 
 describe("Runtime - Input Creation", () => {
   test("should create Bash input correctly", () => {
-    const input = createBashInput("PreToolUse", "echo test");
+    const input = createBashInput(
+      "PreToolUse",
+      "echo test"
+    ) as PreToolUseHookInput;
 
     expect(input.hook_event_name).toBe("PreToolUse");
     expect(input.tool_name).toBe("Bash");
     expect(input.session_id).toBe("test-session");
-    expect(input.tool_input).toEqual({ command: "echo test" });
+    expect((input.tool_input as { command: string }).command).toBe("echo test");
   });
 
   test("should create File input for Write operation", () => {
-    const input = createFileInput("PostToolUse", "Write", "test.ts");
+    const input = createFileInput(
+      "PostToolUse",
+      "Write",
+      "test.ts"
+    ) as PostToolUseHookInput;
 
     expect(input.hook_event_name).toBe("PostToolUse");
     expect(input.tool_name).toBe("Write");
-    expect(input.tool_input.file_path).toBe("test.ts");
+    expect((input.tool_input as { file_path: string }).file_path).toBe(
+      "test.ts"
+    );
   });
 
   test("should create File input for Edit operation", () => {
-    const input = createFileInput("PreToolUse", "Edit", "test.ts");
+    const input = createFileInput(
+      "PreToolUse",
+      "Edit",
+      "test.ts"
+    ) as PreToolUseHookInput;
 
     expect(input.hook_event_name).toBe("PreToolUse");
     expect(input.tool_name).toBe("Edit");
-    expect(input.tool_input.file_path).toBe("test.ts");
+    expect((input.tool_input as { file_path: string }).file_path).toBe(
+      "test.ts"
+    );
   });
 
   test("should create File input for Read operation", () => {
-    const input = createFileInput("PreToolUse", "Read", "test.ts");
+    const input = createFileInput(
+      "PreToolUse",
+      "Read",
+      "test.ts"
+    ) as PreToolUseHookInput;
 
     expect(input.hook_event_name).toBe("PreToolUse");
     expect(input.tool_name).toBe("Read");
-    expect(input.tool_input.file_path).toBe("test.ts");
+    expect((input.tool_input as { file_path: string }).file_path).toBe(
+      "test.ts"
+    );
   });
 
   test("should pass-through input creation", () => {
-    const originalInput = {
-      hook_event_name: "SessionStart" as const,
+    const originalInput: SessionStartHookInput = {
+      hook_event_name: "SessionStart",
       session_id: "my-session",
       transcript_path: "/my/transcript.md",
       cwd: "/my/cwd",
+      source: "startup",
     };
 
     const context = createHookContext(originalInput);
@@ -98,10 +133,11 @@ describe("Runtime - Hook Execution", () => {
       createBashInput("PreToolUse", "test command")
     );
     const result = await safeHookExecution(handler, context);
+    const sync = expectSyncResult(result);
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Hook executed");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Hook executed");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 
   test("should handle hook errors properly", async () => {
@@ -113,10 +149,11 @@ describe("Runtime - Hook Execution", () => {
       createBashInput("PreToolUse", "test command")
     );
     const result = await safeHookExecution(handler, context);
+    const sync = expectSyncResult(result);
 
-    expect(result.continue).toBe(false);
-    expect(result.systemMessage).toBe("Hook failed");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    expect(sync.continue).toBe(false);
+    expect(sync.systemMessage).toBe("Hook failed");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 
   test("should handle security blocking", async () => {
@@ -138,11 +175,12 @@ describe("Runtime - Hook Execution", () => {
       createBashInput("PreToolUse", "rm -rf /")
     );
     const result = await safeHookExecution(handler, context);
+    const sync = expectSyncResult(result);
 
-    expect(result.continue).toBe(false);
-    expect(result.systemMessage).toBe("Dangerous command blocked");
-    expect(result.stopReason).toBe("blocked");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    expect(sync.continue).toBe(false);
+    expect(sync.systemMessage).toBe("Dangerous command blocked");
+    expect(sync.stopReason).toBe("blocked");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 
   test("should handle hook with fallback", async () => {
@@ -156,10 +194,11 @@ describe("Runtime - Hook Execution", () => {
       createBashInput("PreToolUse", "test command")
     );
     const result = await safeHookExecution(handler, context, fallback);
+    const sync = expectSyncResult(result);
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Fallback executed");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Fallback executed");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 });
 
@@ -167,37 +206,42 @@ describe("Runtime - HookResults Utility", () => {
   test("should create success result", () => {
     const result = HookResults.success("Success message");
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Success message");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Success message");
   });
 
   test("should create failure result", () => {
     const result = HookResults.failure("Failure message");
 
-    expect(result.continue).toBe(false);
-    expect(result.systemMessage).toBe("Failure message");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(false);
+    expect(sync.systemMessage).toBe("Failure message");
   });
 
   test("should create block result", () => {
     const result = HookResults.block("Blocked message");
 
-    expect(result.continue).toBe(false);
-    expect(result.systemMessage).toBe("Blocked message");
-    expect(result.stopReason).toBe("blocked");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(false);
+    expect(sync.systemMessage).toBe("Blocked message");
+    expect(sync.stopReason).toBe("blocked");
   });
 
   test("should create skip result", () => {
     const result = HookResults.skip("Skip message");
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Skip message");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Skip message");
   });
 
   test("should create warn result", () => {
     const result = HookResults.warn("Warning message");
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Warning message");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Warning message");
   });
 });
 
@@ -254,10 +298,11 @@ describe("Runtime - executeHook", () => {
       createBashInput("PreToolUse", "test command")
     );
     const result = await executeHook(handler, context, { timeout: 1000 });
+    const sync = expectSyncResult(result);
 
-    expect(result.continue).toBe(true);
-    expect(result.systemMessage).toBe("Success");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    expect(sync.continue).toBe(true);
+    expect(sync.systemMessage).toBe("Success");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 
   test("should timeout and return failure", async () => {
@@ -274,9 +319,10 @@ describe("Runtime - executeHook", () => {
       throwOnError: false,
     });
 
-    expect(result.continue).toBe(false);
-    expect(result.systemMessage).toContain("timed out");
-    expect(result.metadata?.provider?.id).toBe("claude");
+    const sync = expectSyncResult(result);
+    expect(sync.continue).toBe(false);
+    expect(sync.systemMessage).toContain("timed out");
+    expect(sync.metadata?.provider?.id).toBe("claude");
   });
 
   test("should complete before timeout", async () => {
@@ -298,11 +344,12 @@ describe("Runtime - executeHook", () => {
         createBashInput("PreToolUse", "test command")
       );
       const result = await executeHook(handler, context, { timeout: 1000 });
+      const sync = expectSyncResult(result);
 
-      expect(result.continue).toBe(true);
-      expect(result.systemMessage).toBe("Fast execution");
+      expect(sync.continue).toBe(true);
+      expect(sync.systemMessage).toBe("Fast execution");
       expect(timerCleared).toBe(true);
-      expect(result.metadata?.provider?.id).toBe("claude");
+      expect(sync.metadata?.provider?.id).toBe("claude");
     } finally {
       // Restore original clearTimeout
       globalThis.clearTimeout = originalClearTimeout;
@@ -331,10 +378,11 @@ describe("Runtime - executeHook", () => {
         throwOnError: false,
       });
 
-      expect(result.continue).toBe(false);
-      expect(result.systemMessage).toBe("Handler error");
+      const sync = expectSyncResult(result);
+      expect(sync.continue).toBe(false);
+      expect(sync.systemMessage).toBe("Handler error");
       expect(timerCleared).toBe(true);
-      expect(result.metadata?.provider?.id).toBe("claude");
+      expect(sync.metadata?.provider?.id).toBe("claude");
     } finally {
       globalThis.clearTimeout = originalClearTimeout;
     }

--- a/packages/hooks-core/src/__tests__/tool-scoping.test.ts
+++ b/packages/hooks-core/src/__tests__/tool-scoping.test.ts
@@ -11,7 +11,7 @@ import {
   HookResults,
   isBashToolInput,
 } from "../runtime.ts";
-import type { HookContext, HookJSONOutput } from "../types.ts";
+import type { HookContext, HookJSONOutput, HookResult } from "../types.ts";
 
 // Mock input helper that matches the actual HookInput structure
 function createMockContext(
@@ -26,6 +26,21 @@ function createMockContext(
     baseInput.tool_response = baseInput.tool_response ?? "Command executed";
   }
   return createHookContext(baseInput);
+}
+
+function expectSync<T extends HookJSONOutput | HookResult>(
+  result: T
+): Exclude<T, { async: true }> {
+  if ((result as { async?: boolean }).async === true) {
+    throw new Error("Expected synchronous hook result");
+  }
+  return result as Exclude<T, { async: true }>;
+}
+
+function expectSyncArray<T extends HookJSONOutput | HookResult>(
+  results: readonly T[]
+): Exclude<T, { async: true }>[] {
+  return results.map((result) => expectSync(result));
 }
 
 describe("Tool Scoping Fix - Registry Core", () => {
@@ -88,9 +103,9 @@ describe("Tool Scoping Fix - Registry Core", () => {
   });
 
   test("mixed universal and tool-specific hooks execute correctly", async () => {
-    const universalHandler = mock().mockResolvedValue({ continue: true });
-    const bashHandler = mock().mockResolvedValue({ continue: true });
-    const writeHandler = mock().mockResolvedValue({ continue: true });
+    const universalHandler = mock().mockResolvedValue(HookResults.success());
+    const bashHandler = mock().mockResolvedValue(HookResults.success());
+    const writeHandler = mock().mockResolvedValue(HookResults.success());
 
     registry.register(
       HookBuilder.forPreToolUse().withHandler(universalHandler).build()
@@ -144,22 +159,22 @@ describe("Tool Scoping Fix - Registry Core", () => {
 
     const universalLow = mock().mockImplementation(() => {
       results.push("universal-low");
-      return { continue: true };
+      return HookResults.success();
     });
 
     const universalHigh = mock().mockImplementation(() => {
       results.push("universal-high");
-      return { continue: true };
+      return HookResults.success();
     });
 
     const bashLow = mock().mockImplementation(() => {
       results.push("bash-low");
-      return { continue: true };
+      return HookResults.success();
     });
 
     const bashHigh = mock().mockImplementation(() => {
       results.push("bash-high");
-      return { continue: true };
+      return HookResults.success();
     });
 
     // Register hooks with different priorities
@@ -286,13 +301,11 @@ describe("Tool Scoping Fix - Function-Based API", () => {
 
   test("createHook throws error when tool specified without handler", () => {
     expect(() => {
-      // @ts-expect-error Testing error case
-      createHook.preToolUse("Bash");
+      createHook.preToolUse("Bash", undefined as any);
     }).toThrow("Handler is required when tool is specified");
 
     expect(() => {
-      // @ts-expect-error Testing error case
-      createHook.postToolUse("Write");
+      createHook.postToolUse("Write", undefined as any);
     }).toThrow("Handler is required when tool is specified");
   });
 });
@@ -342,8 +355,6 @@ describe("Tool Scoping Fix - Integration Tests", () => {
   });
 
   test("security validation scenario: block dangerous commands only for Bash", async () => {
-    const _results: HookJSONOutput[] = [];
-
     // Universal hook (allows all)
     const universalHook = createHook.preToolUse(() => {
       return HookResults.success("Universal validation passed");
@@ -365,33 +376,40 @@ describe("Tool Scoping Fix - Integration Tests", () => {
     registry.register(bashSecurityHook);
 
     // Test safe Bash command (should pass both)
-    const safeBashResults = await registry.execute(
-      createHookContext(createBashInput("PreToolUse", "echo safe"), {
-        tool_input: { command: 'echo "hello world"' },
-      })
+    const safeBashResults = expectSyncArray(
+      await registry.execute(
+        createHookContext(createBashInput("PreToolUse", "echo safe"), {
+          tool_input: { command: 'echo "hello world"' },
+        })
+      )
     );
     expect(safeBashResults).toHaveLength(2);
     expect(safeBashResults.every((r) => r.continue)).toBe(true);
 
     // Test dangerous Bash command (should be blocked)
-    const dangerousBashResults = await registry.execute(
-      createHookContext(createBashInput("PreToolUse", "echo dangerous"), {
-        tool_input: { command: "rm -rf /" },
-      })
+    const dangerousBashResults = expectSyncArray(
+      await registry.execute(
+        createHookContext(createBashInput("PreToolUse", "echo dangerous"), {
+          tool_input: { command: "rm -rf /" },
+        })
+      )
     );
     expect(dangerousBashResults).toHaveLength(2);
-    expect(dangerousBashResults[0].continue).toBe(true); // Universal passes
-    expect(dangerousBashResults[1].continue).toBe(false); // Bash security blocks
+    const [universalDanger, bashDanger] = dangerousBashResults;
+    expect(universalDanger?.continue).toBe(true); // Universal passes
+    expect(bashDanger?.continue).toBe(false); // Bash security blocks
 
     // Test Write tool with dangerous-looking content (should pass - no Bash security)
-    const writeResults = await registry.execute(
-      createHookContext(createBashInput("PreToolUse", "echo write"), {
-        tool_name: "Write",
-        tool_input: { file_path: "script.sh", content: "rm -rf /" },
-      })
+    const writeResults = expectSyncArray(
+      await registry.execute(
+        createHookContext(createBashInput("PreToolUse", "echo write"), {
+          tool_name: "Write",
+          tool_input: { file_path: "script.sh", content: "rm -rf /" },
+        })
+      )
     );
     expect(writeResults).toHaveLength(1); // Only universal hook
-    expect(writeResults[0].continue).toBe(true);
+    expect(writeResults[0]?.continue).toBe(true);
   });
 
   test("performance monitoring: tool-specific vs universal hooks", async () => {
@@ -403,7 +421,7 @@ describe("Tool Scoping Fix - Integration Tests", () => {
     registry.register(
       createHook.preToolUse(() => {
         universalExecutions++;
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -411,7 +429,7 @@ describe("Tool Scoping Fix - Integration Tests", () => {
     registry.register(
       createHook.preToolUse("Bash", () => {
         bashExecutions++;
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -419,7 +437,7 @@ describe("Tool Scoping Fix - Integration Tests", () => {
     registry.register(
       createHook.preToolUse("Write", () => {
         writeExecutions++;
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -457,7 +475,7 @@ describe("Tool Scoping Fix - Error Scenarios", () => {
     registry.register(
       createHook.preToolUse(() => {
         results.push("universal");
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -465,7 +483,7 @@ describe("Tool Scoping Fix - Error Scenarios", () => {
     registry.register(
       createHook.preToolUse("Bash", () => {
         results.push("bash-blocker");
-        return { continue: false, systemMessage: "Blocked by bash hook" };
+        return HookResults.block("Blocked by bash hook");
       })
     );
 
@@ -473,7 +491,7 @@ describe("Tool Scoping Fix - Error Scenarios", () => {
     registry.register(
       createHook.preToolUse("Bash", () => {
         results.push("bash-after-blocker");
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -501,7 +519,7 @@ describe("Tool Scoping Fix - Error Scenarios", () => {
     registry.register(
       createHook.preToolUse("Bash", () => {
         results.push("bash-after-error");
-        return { continue: true };
+        return HookResults.success();
       })
     );
 
@@ -513,7 +531,7 @@ describe("Tool Scoping Fix - Error Scenarios", () => {
     expect(results).not.toContain("bash-after-error"); // Execution stopped due to blocking error
 
     expect(hookResults).toHaveLength(1);
-    expect(hookResults[0].continue).toBe(false);
+    expect(expectSync(hookResults[0]!).continue).toBe(false);
   });
 });
 
@@ -523,23 +541,27 @@ describe("Tool Scoping Fix - Backward Compatibility", () => {
 
     // Old pattern: builder without forTool (should be universal)
     const oldBuilderHook = HookBuilder.forPreToolUse()
-      .withHandler(mock().mockResolvedValue({ continue: true }))
+      .withHandler(mock().mockResolvedValue(HookResults.success()))
       .build();
 
     registry.register(oldBuilderHook);
 
     // Should work for any tool
-    const bashResult = await registry.execute(
-      createMockContext("PreToolUse", { toolName: "Bash" })
+    const bashResult = expectSyncArray(
+      await registry.execute(
+        createMockContext("PreToolUse", { toolName: "Bash" })
+      )
     );
-    const writeResult = await registry.execute(
-      createMockContext("PreToolUse", { toolName: "Write" })
+    const writeResult = expectSyncArray(
+      await registry.execute(
+        createMockContext("PreToolUse", { toolName: "Write" })
+      )
     );
 
     expect(bashResult).toHaveLength(1);
     expect(writeResult).toHaveLength(1);
-    expect(bashResult[0].continue).toBe(true);
-    expect(writeResult[0].continue).toBe(true);
+    expect(bashResult[0]?.continue).toBe(true);
+    expect(writeResult[0]?.continue).toBe(true);
   });
 
   test("manual hook registry entries work with new system", () => {
@@ -548,7 +570,7 @@ describe("Tool Scoping Fix - Backward Compatibility", () => {
     // Manual registry entry (old style - no matcher field)
     registry.register({
       event: "PreToolUse",
-      handler: mock().mockResolvedValue({ continue: true }),
+      handler: mock().mockResolvedValue(HookResults.success()),
       priority: 0,
       enabled: true,
       // No matcher field - should be universal

--- a/packages/hooks-core/src/__tests__/verification-demo.ts
+++ b/packages/hooks-core/src/__tests__/verification-demo.ts
@@ -4,26 +4,23 @@
  */
 
 import { createHook, HookBuilder, HookRegistry } from "../index.ts";
+import { createHookContext, HookResults } from "../runtime.ts";
+import type { PreToolUseHookInput } from "../types.ts";
 
 // Mock context helper
 function createMockContext(event: "PreToolUse", toolName: string) {
-  return {
-    event,
-    toolName,
-    sessionId: "demo-session",
-    transcriptPath: "/demo/transcript",
+  const input: PreToolUseHookInput = {
+    hook_event_name: event,
+    session_id: "demo-session",
+    transcript_path: "/demo/transcript",
     cwd: process.cwd(),
-    toolInput: { command: "echo demo" },
-    environment: {},
-    rawInput: {
-      session_id: "demo-session",
-      transcript_path: "/demo/transcript",
-      cwd: process.cwd(),
-      hook_event_name: event,
-      tool_name: toolName,
-      tool_input: { command: "echo demo" },
-    },
-  } as Record<string, unknown>;
+    tool_name: toolName,
+    tool_input: { command: "echo demo" },
+  };
+
+  return createHookContext(input, undefined, {
+    environment: { CLAUDE_PROJECT_DIR: process.cwd() },
+  });
 }
 
 async function demonstrateToolScopingFix() {
@@ -31,22 +28,18 @@ async function demonstrateToolScopingFix() {
 
   // 1. Universal hook (runs for all tools)
   const universalHook = HookBuilder.forPreToolUse()
-    .withHandler(async (_context) => {
-      return { success: true };
-    })
+    .withHandler(async () => HookResults.success())
     .build();
 
   // 2. Bash-specific hook (runs only for Bash)
   const bashHook = HookBuilder.forPreToolUse()
     .forTool("Bash")
-    .withHandler(async (_context) => {
-      return { success: true };
-    })
+    .withHandler(async () => HookResults.success())
     .build();
 
   // 3. Write-specific hook using function API
-  const writeHook = createHook.preToolUse("Write", async (_context) => {
-    return { success: true };
+  const writeHook = createHook.preToolUse("Write", async () => {
+    return HookResults.success();
   });
 
   registry.register(universalHook);
@@ -55,9 +48,9 @@ async function demonstrateToolScopingFix() {
   await registry.execute(createMockContext("PreToolUse", "Bash"));
   await registry.execute(createMockContext("PreToolUse", "Write"));
   await registry.execute(createMockContext("PreToolUse", "Edit"));
-  const _bashHooks = registry.getHooks("PreToolUse", "Bash");
-  const _writeHooks = registry.getHooks("PreToolUse", "Write");
-  const _editHooks = registry.getHooks("PreToolUse", "Edit");
+  registry.getHooks("PreToolUse", "Bash");
+  registry.getHooks("PreToolUse", "Write");
+  registry.getHooks("PreToolUse", "Edit");
 }
 
 // Only run demo if this file is executed directly

--- a/packages/hooks-core/src/logging/__tests__/logging.test.ts
+++ b/packages/hooks-core/src/logging/__tests__/logging.test.ts
@@ -209,8 +209,13 @@ test("sanitizer handles deep nested objects", () => {
   };
 
   // Should traverse deep structures
-  expect(sanitized.level1.level2.level3.data).toBe("normal");
-  expect(sanitized.level1.level2.level3.password).toBeUndefined();
+  expect(sanitized.level1?.level2?.level3).toBeDefined();
+  const level3 = sanitized.level1?.level2?.level3;
+  if (!level3) {
+    throw new Error("Expected level3 to be defined after sanitizer traversal");
+  }
+  expect(level3.data).toBe("normal");
+  expect(level3.password).toBeUndefined();
 });
 
 test("sanitizer handles arrays correctly", () => {
@@ -226,10 +231,11 @@ test("sanitizer handles arrays correctly", () => {
   }>;
 
   expect(Array.isArray(sanitized)).toBe(true);
-  expect(sanitized[0].name).toBe("item1");
-  expect(sanitized[0].password).toBeUndefined();
-  expect(sanitized[1].name).toBe("item2");
-  expect(sanitized[1].token).toBeUndefined();
+  expect(sanitized).toHaveLength(2);
+  expect(sanitized[0]?.name).toBe("item1");
+  expect(sanitized[0]?.password).toBeUndefined();
+  expect(sanitized[1]?.name).toBe("item2");
+  expect(sanitized[1]?.token).toBeUndefined();
 });
 
 test("hook logger logs execution lifecycle", () => {

--- a/packages/hooks-core/src/providers/claude-adapter.ts
+++ b/packages/hooks-core/src/providers/claude-adapter.ts
@@ -128,6 +128,10 @@ function denormalizeHookResult(result: NormalizedHookResult): HookJSONOutput {
   const {
     providerState: _providerState,
     metadata: _metadata,
+    success: _legacySuccess,
+    message: _legacyMessage,
+    block: _legacyBlock,
+    data: _legacyData,
     ...json
   } = result;
   return { ...json } as HookJSONOutput;

--- a/packages/hooks-core/src/providers/types.ts
+++ b/packages/hooks-core/src/providers/types.ts
@@ -1,81 +1,8 @@
-import type { LiteralUnion } from "type-fest";
-import type {
-  HookEnvironment,
-  HookEvent,
-  HookJSONOutput,
-  HookResult,
-  ToolInput,
-  ToolName,
+export type {
+  HookProviderAdapter,
+  HookProviderId,
+  HookProviderMetadata,
+  NormalizedHookContext,
+  NormalizedHookResult,
+  NormalizedToolContext,
 } from "../types";
-
-export type HookProviderId = LiteralUnion<"claude", string>;
-
-export type HookProviderMetadata = {
-  /** Unique identifier for the provider (human readable slug). */
-  readonly id: HookProviderId;
-  /** Human facing provider name. */
-  readonly name: string;
-  /** Optional marketing/display name. */
-  readonly displayName?: string;
-  /** Version of the underlying SDK/runtime. */
-  readonly version: string;
-  /** Runtime identifier (e.g. "claude-code", "openai-code"). */
-  readonly runtime: string;
-  readonly supports: {
-    /** Hook events supported by this provider. */
-    readonly events: readonly HookEvent[];
-    /** Tool names supported by this provider (subset is fine). */
-    readonly tools?: readonly ToolName[];
-    /** Optional feature flags/capabilities. */
-    readonly capabilities?: readonly string[];
-  };
-  readonly links?: {
-    readonly homepage?: string;
-    readonly docs?: string;
-  };
-};
-
-export type NormalizedToolContext = {
-  readonly name?: ToolName;
-  readonly input?: ToolInput | Record<string, unknown>;
-  readonly response?: unknown;
-};
-
-export type NormalizedHookContext<TProviderInput = unknown> = {
-  readonly event: HookEvent;
-  readonly sessionId: string;
-  readonly cwd: string;
-  readonly transcriptPath?: string;
-  readonly userPrompt?: string;
-  readonly environment: HookEnvironment;
-  readonly tool?: NormalizedToolContext;
-  readonly raw: TProviderInput;
-  readonly metadata: {
-    readonly provider: HookProviderMetadata;
-    readonly receivedAt: string;
-  };
-};
-
-export type NormalizedHookResult = HookResult;
-
-export type HookProviderAdapter<
-  TProviderInput = unknown,
-  TProviderOutput = HookJSONOutput,
-> = {
-  readonly id: HookProviderId;
-  readonly metadata: HookProviderMetadata;
-  /**
-   * Normalize raw provider input into Carabiner's provider-neutral context shape.
-   */
-  fromProviderInput(
-    input: TProviderInput,
-    environment?: HookEnvironment
-  ): NormalizedHookContext<TProviderInput>;
-  /**
-   * Convert the normalized hook result back into a provider specific payload.
-   */
-  toProviderOutput(
-    result: NormalizedHookResult,
-    context: NormalizedHookContext<TProviderInput>
-  ): TProviderOutput;
-};

--- a/packages/hooks-core/src/runtime.ts
+++ b/packages/hooks-core/src/runtime.ts
@@ -35,6 +35,12 @@ import { HookError, HookInputError, HookTimeoutError } from "./types";
 
 type ClaudeProviderAdapter = HookProviderAdapter<HookInput, HookJSONOutput>;
 
+type CreateHookContextOptions = {
+  environment?: HookEnvironment;
+  providerId?: HookProviderId;
+  provider?: ClaudeProviderAdapter;
+};
+
 function resolveProvider(
   options: HookExecutionOptions = {}
 ): ClaudeProviderAdapter {
@@ -268,12 +274,18 @@ export function parseToolInput<T extends ToolName>(
 export function createHookContext<T extends HookInput = HookInput>(
   providerInput: T,
   overrides?: Partial<T>,
-  options: {
-    environment?: HookEnvironment;
-    providerId?: HookProviderId;
-    provider?: ClaudeProviderAdapter;
-  } = {}
-): HookContext<T> {
+  options?: CreateHookContextOptions
+): HookContext<T>;
+export function createHookContext<E extends HookEvent = HookEvent>(
+  providerInput: E,
+  overrides?: Partial<HookInput>,
+  options?: CreateHookContextOptions
+): HookContext;
+export function createHookContext(
+  providerInput: HookInput | HookEvent,
+  overrides?: Partial<HookInput>,
+  options: CreateHookContextOptions = {}
+): HookContext {
   const provider = resolveProvider({
     provider: options.provider,
     providerId: options.providerId,
@@ -282,11 +294,11 @@ export function createHookContext<T extends HookInput = HookInput>(
   const environment = options.environment ?? parseHookEnvironment();
   const baseInput = ensureHookInput(providerInput, environment);
   const mergedInput = overrides
-    ? ({ ...baseInput, ...overrides } as T)
+    ? ({ ...baseInput, ...overrides } as HookInput)
     : baseInput;
 
   const normalized = provider.fromProviderInput(mergedInput, environment);
-  return toHookContext(normalized) as HookContext<T>;
+  return toHookContext(normalized);
 }
 
 /**
@@ -534,12 +546,15 @@ export async function runClaudeHook(
 
     outputHookResult(providerResult);
   } catch (error) {
+    const systemMessage =
+      error instanceof Error
+        ? error.message
+        : "Unknown error during hook execution";
     const failure: HookResult = {
       continue: false,
-      systemMessage:
-        error instanceof Error
-          ? error.message
-          : "Unknown error during hook execution",
+      systemMessage,
+      success: false,
+      message: systemMessage,
       metadata: {
         timestamp: new Date().toISOString(),
         ...(provider ? { provider: provider.metadata } : {}),
@@ -576,10 +591,20 @@ export function getSessionInfo(): { projectDir?: string } {
  */
 export const HookResults = {
   success(systemMessage?: string): HookResult {
-    return { continue: true, systemMessage };
+    return {
+      continue: true,
+      systemMessage,
+      success: true,
+      message: systemMessage,
+    };
   },
   failure(systemMessage: string): HookResult {
-    return { continue: false, systemMessage };
+    return {
+      continue: false,
+      systemMessage,
+      success: false,
+      message: systemMessage,
+    };
   },
   block(systemMessage: string, suppressOutput = false): HookResult {
     return {
@@ -587,16 +612,26 @@ export const HookResults = {
       systemMessage,
       stopReason: "blocked",
       ...(suppressOutput && { suppressOutput }),
+      success: false,
+      message: systemMessage,
+      block: true,
     };
   },
   skip(systemMessage?: string): HookResult {
     return {
       continue: true,
       systemMessage: systemMessage || "Hook skipped",
+      success: true,
+      message: systemMessage || "Hook skipped",
     };
   },
   warn(systemMessage: string): HookResult {
-    return { continue: true, systemMessage };
+    return {
+      continue: true,
+      systemMessage,
+      success: true,
+      message: systemMessage,
+    };
   },
 };
 
@@ -608,42 +643,54 @@ export async function safeHookExecution(
   context: HookContext,
   fallback?: () => HookResult
 ): Promise<HookResult> {
+  const abortController = new AbortController();
+  const startedAt = Date.now();
   try {
     const result = await Promise.resolve(
-      handler(context, undefined, { signal: new AbortController().signal })
+      handler(context, undefined, { signal: abortController.signal })
     );
 
     const normalized = result as HookResult;
+    const metadata: HookMetadata = {
+      provider: context.metadata.provider,
+      timestamp: new Date().toISOString(),
+      duration: Date.now() - startedAt,
+      ...(normalized.metadata ?? {}),
+    };
     return {
       ...normalized,
-      metadata: {
-        provider: context.metadata.provider,
-        ...(normalized.metadata ?? {}),
-      },
+      metadata,
     } satisfies HookResult;
   } catch (error) {
     if (fallback) {
-      const fallbackResult = fallback();
+      const fallbackResult = await Promise.resolve(fallback());
+      const metadata: HookMetadata = {
+        provider: context.metadata.provider,
+        timestamp: new Date().toISOString(),
+        duration: Date.now() - startedAt,
+        ...(fallbackResult.metadata ?? {}),
+      };
       return {
         ...fallbackResult,
-        metadata: {
-          provider: context.metadata.provider,
-          ...(fallbackResult.metadata ?? {}),
-        },
+        metadata,
       } satisfies HookResult;
     }
 
     const failure = HookResults.failure(
       error instanceof Error ? error.message : "Unknown error occurred"
     );
-
+    const metadata: HookMetadata = {
+      provider: context.metadata.provider,
+      timestamp: new Date().toISOString(),
+      duration: Date.now() - startedAt,
+      ...(failure.metadata ?? {}),
+    };
     return {
       ...failure,
-      metadata: {
-        provider: context.metadata.provider,
-        ...(failure.metadata ?? {}),
-      },
+      metadata,
     } satisfies HookResult;
+  } finally {
+    abortController.abort();
   }
 }
 

--- a/packages/hooks-core/src/types.ts
+++ b/packages/hooks-core/src/types.ts
@@ -4,13 +4,6 @@
  */
 
 import type { LiteralUnion, Simplify } from "type-fest";
-import type {
-  HookProviderAdapter,
-  HookProviderId,
-  HookProviderMetadata,
-  NormalizedHookContext,
-  NormalizedToolContext,
-} from "./providers";
 
 // Re-export all Claude Code SDK types for convenience
 export type {
@@ -176,6 +169,46 @@ export type UnknownToolInput = Record<string, unknown>;
  */
 export type ToolInput = ToolInputMap[keyof ToolInputMap] | UnknownToolInput;
 
+export type HookProviderId = LiteralUnion<"claude", string>;
+
+export type HookProviderMetadata = {
+  readonly id: HookProviderId;
+  readonly name: string;
+  readonly displayName?: string;
+  readonly version: string;
+  readonly runtime: string;
+  readonly supports: {
+    readonly events: readonly HookEvent[];
+    readonly tools?: readonly ToolName[];
+    readonly capabilities?: readonly string[];
+  };
+  readonly links?: {
+    readonly homepage?: string;
+    readonly docs?: string;
+  };
+};
+
+export type NormalizedToolContext = {
+  readonly name?: ToolName;
+  readonly input?: ToolInput | Record<string, unknown>;
+  readonly response?: unknown;
+};
+
+export type NormalizedHookContext<TProviderInput = unknown> = {
+  readonly event: HookEvent;
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly transcriptPath?: string;
+  readonly userPrompt?: string;
+  readonly environment: HookEnvironment;
+  readonly tool?: NormalizedToolContext;
+  readonly raw: TProviderInput;
+  readonly metadata: {
+    readonly provider: HookProviderMetadata;
+    readonly receivedAt: string;
+  };
+};
+
 type MaybePromise<T> = T | Promise<T>;
 
 /**
@@ -219,9 +252,38 @@ export type HookMetadata = {
   provider?: HookProviderMetadata;
 };
 
+type LegacyHookResultCompat = {
+  /** @deprecated use continue */
+  success?: boolean;
+  /** @deprecated use systemMessage */
+  message?: string;
+  /** @deprecated use stopReason === "blocked" */
+  block?: boolean;
+  /** @deprecated provide structured metadata instead */
+  data?: Record<string, unknown>;
+};
+
 export type HookResult = HookJSONOutput & {
   metadata?: HookMetadata;
   providerState?: Record<string, unknown>;
+} & LegacyHookResultCompat;
+
+export type NormalizedHookResult = HookResult;
+
+export type HookProviderAdapter<
+  TProviderInput = unknown,
+  TProviderOutput = HookJSONOutput,
+> = {
+  readonly id: HookProviderId;
+  readonly metadata: HookProviderMetadata;
+  fromProviderInput(
+    input: TProviderInput,
+    environment?: HookEnvironment
+  ): NormalizedHookContext<TProviderInput>;
+  toProviderOutput(
+    result: NormalizedHookResult,
+    context: NormalizedHookContext<TProviderInput>
+  ): TProviderOutput;
 };
 
 /**

--- a/packages/hooks-registry/examples/markdown-formatter.example.ts
+++ b/packages/hooks-registry/examples/markdown-formatter.example.ts
@@ -7,8 +7,11 @@
  */
 
 import { HookExecutor } from "@carabiner/execution";
-import { createMarkdownFormatterHook } from "@carabiner/hooks-registry";
 import { StdinProtocol } from "@carabiner/protocol";
+// Preferred for consumers:
+// import { createMarkdownFormatterHook } from "@carabiner/hooks-registry";
+// Local development in this repo:
+import { createMarkdownFormatterHook } from "../src/hooks/markdown-formatter";
 
 // Example 1: Basic usage with auto-detection
 const basicHook = createMarkdownFormatterHook();

--- a/packages/plugins/src/__tests__/git-safety.test.ts
+++ b/packages/plugins/src/__tests__/git-safety.test.ts
@@ -4,11 +4,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type {
+  HookEvent,
+  HookInput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+} from "@carabiner/hooks-core";
 import { createHookContext } from "@carabiner/hooks-core";
-import type { HookEvent } from "@carabiner/types";
 import { gitSafetyPlugin } from "../git-safety/index";
 
-type TestHookContext = ReturnType<typeof createHookContext>;
+type TestHookContext = Parameters<typeof gitSafetyPlugin.apply>[0];
 
 type ContextOptions = {
   event?: HookEvent;
@@ -23,25 +28,41 @@ const createContext = ({
   toolInput = { command: "echo" },
   cwd = "/test/repo",
 }: ContextOptions = {}): TestHookContext => {
-  const overrides: Record<string, unknown> = {
-    session_id: "test-session",
-    transcript_path: "/tmp/transcript",
-    cwd,
-    tool_name: toolName,
-    tool_input: toolInput,
-  };
-
-  if (event === "PostToolUse") {
-    overrides.tool_response = overrides.tool_response ?? { stdout: "" };
+  let input: HookInput;
+  if (event === "PreToolUse") {
+    const preInput = {
+      hook_event_name: event,
+      session_id: "test-session",
+      transcript_path: "/tmp/transcript",
+      cwd,
+      tool_name: toolName,
+      tool_input: toolInput,
+    } satisfies PreToolUseHookInput;
+    input = preInput;
+  } else if (event === "PostToolUse") {
+    const postInput = {
+      hook_event_name: event,
+      session_id: "test-session",
+      transcript_path: "/tmp/transcript",
+      cwd,
+      tool_name: toolName,
+      tool_input: toolInput,
+      tool_response: { exit_code: 0, stdout: "", stderr: "" },
+    } satisfies PostToolUseHookInput;
+    input = postInput;
+  } else {
+    throw new Error(`Unsupported event for git-safety tests: ${event}`);
   }
 
-  return createHookContext(event, overrides, {
+  return createHookContext(input, undefined, {
     environment: { CLAUDE_PROJECT_DIR: cwd },
-  });
+  }) as unknown as TestHookContext;
 };
 
-const createBashContext = (command: string): TestHookContext =>
-  createContext({ toolInput: { command } });
+const createBashContext = (
+  command: string,
+  options: Partial<Pick<ContextOptions, "cwd">> = {}
+): TestHookContext => createContext({ toolInput: { command }, ...options });
 
 const createNonBashContext = (): TestHookContext =>
   createContext({
@@ -257,8 +278,9 @@ describe("Git Safety Plugin", () => {
         excludeRepos: ["/tmp/.*", ".*test.*"],
       };
 
-      const context = createBashContext("git push --force");
-      context.cwd = "/tmp/test-repo" as any;
+      const context = createBashContext("git push --force", {
+        cwd: "/tmp/test-repo",
+      });
 
       const result = await gitSafetyPlugin.apply(context, config);
 
@@ -272,16 +294,18 @@ describe("Git Safety Plugin", () => {
       };
 
       // Should skip repo not in include list
-      const context1 = createBashContext("git push --force");
-      context1.cwd = "/unimportant/repo" as any;
+      const context1 = createBashContext("git push --force", {
+        cwd: "/unimportant/repo",
+      });
 
       const result1 = await gitSafetyPlugin.apply(context1, config);
       expect(result1.success).toBe(true);
       expect(result1.metadata?.skipped).toBe(true);
 
       // Should process repo in include list
-      const context2 = createBashContext("git push --force");
-      context2.cwd = "/important/repo" as any;
+      const context2 = createBashContext("git push --force", {
+        cwd: "/important/repo",
+      });
 
       const result2 = await gitSafetyPlugin.apply(context2, config);
       expect(result2.success).toBe(false);


### PR DESCRIPTION
## Summary
- align hook context results with legacy `success`/`message` fields while maintaining the new structured payloads
- harden test helpers to avoid top-level assertions and guard against async hook results
- move provider type definitions into `hooks-core` types to eliminate provider/type circular deps raised by CI

## Testing
- bun run format:check
- bun run type-check
- bun test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Richer hook results with standardized success/message/block fields.
  - New safe execution utility for hooks with fallback handling.
  - Enhanced context creation options for environment and provider.
  - CLI now validates presence of a hook command; returns JSON failure and exits when missing.

- Refactor
  - Provider output JSON omits legacy fields and metadata for cleaner results.
  - Examples updated to use standardized result helpers and context creation.
  - Minor example import path adjustment.

- Tests
  - Broad test updates with stricter typing and new helpers for synchronous results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->