### PR TITLE
docs: document custom logger factory override

### DIFF
--- a/.agents/notes/logger-and-tests-plan.md
+++ b/.agents/notes/logger-and-tests-plan.md
@@ -67,6 +67,11 @@ The new work will sit on top of the stack to avoid re-ordering the existing Grap
 4. Add a changelog entry or note in the migration doc about the new logger override.
 5. Smoke-test by running `bun run check` and the affected example scripts (if practical).
 
+### Status
+- ✅ Added architecture and getting started documentation covering `setLoggerFactory`
+- ✅ Updated README highlights to mention the logger factory override
+- ✅ Verified targeted logging tests and typechecks (`bun test packages/hooks-core/src/logging/__tests__/logging.test.ts`, `turbo typecheck --filter=@carabiner/hooks-core --filter=@carabiner/hooks-config`)
+
 ## 4. Lefthook Automation (`gt/devx-lefthook-lint`)
 **Base branch:** `gt/docs-logger-alignment`
 
@@ -93,4 +98,3 @@ Capture the above in human-readable form (this note) and link it from the top-le
 - Do we want environment-based defaults for the custom logger hook (e.g., allow configuring via env var)? Not in scope for now, but note in the docs.
 - After landing the logging adapter, consider whether the example console calls should migrate to the shared logger or remain illustrative.
 - Ensure Graphite branch order is updated in Graphite after adding new branches (each new slice should be created with `gt create` off the branch noted above).
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -579,6 +579,25 @@ class HookRegistry {
 
 ## Extension Points
 
+### Logger Factory Hooks
+
+Inject a custom factory to redirect structured logs to your observability stack:
+
+```typescript
+import type { LoggerFactory } from '@carabiner/hooks-core';
+import { setLoggerFactory } from '@carabiner/hooks-core';
+
+const loggerFactory: LoggerFactory = (service, config) =>
+  myLogger.child({ service, env: config.environment });
+
+setLoggerFactory(loggerFactory);
+
+// revert to built-in production logger when needed
+setLoggerFactory(null);
+```
+
+All shared helpers (`createLogger`, `coreLogger`, `executionLogger`, etc.) automatically refresh when the factory changes.
+
 ### Custom Middleware
 
 ```typescript


### PR DESCRIPTION
## Summary
- document the new logger factory override in the architecture overview and getting started guide
- link the rollout note so contributors can find the logger/test plan from the docs

## Testing
- n/a (docs only)
